### PR TITLE
rpc-perf 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes 0.2.11 (git+https://github.com/carllerche/bytes?branch=v0.2.x)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,7 +15,7 @@ dependencies = [
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "workload 0.1.0",
+ "workload 0.1.1",
 ]
 
 [[package]]
@@ -249,13 +249,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "workload"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.0 (git+https://github.com/brayniac/mpmc)",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimit 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "request 0.1.0",
+ "shuteye 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/deps/workload/Cargo.toml
+++ b/deps/workload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workload"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"
@@ -12,6 +12,7 @@ log = "0.3.3"
 time = "0.1.24"
 rand = "0.3.11"
 ratelimit = "0.1.8"
+shuteye = "0.0.5"
 
 [dependencies.mpmc]
 git = "https://github.com/brayniac/mpmc"


### PR DESCRIPTION
- workload: add small delay in prepare steps to prevent race for --hit and --flush
- workload: bump version to 0.1.1
- rpc-perf: add warmup of duration seconds w/o stats reporting
- rpc-perf: decouple trace interval from report interval to allow fine-grained traces
- rpc-perf: bump version to 0.1.3
