### PR TITLE
rpc-perf 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes 0.2.11 (git+https://github.com/carllerche/bytes?branch=v0.2.x)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8,14 +8,14 @@ dependencies = [
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.4.3",
  "mpmc 0.1.0 (git+https://github.com/brayniac/mpmc)",
- "parser 0.1.0",
+ "parser 0.1.1",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "request 0.1.0",
+ "request 0.1.1",
  "shuteye 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "workload 0.1.1",
+ "workload 0.1.2",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "request"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -249,13 +249,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "workload"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.0 (git+https://github.com/brayniac/mpmc)",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimit 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "request 0.1.0",
+ "request 0.1.1",
  "shuteye 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/configs/basic.toml
+++ b/configs/basic.toml
@@ -12,4 +12,5 @@ rate = 10000
 [[workload]]
 name = "get"
 method = "get"
+hit = true
 rate = 50000

--- a/deps/parser/Cargo.toml
+++ b/deps/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/deps/parser/src/echo.rs
+++ b/deps/parser/src/echo.rs
@@ -15,11 +15,10 @@
 
 extern crate crc;
 
-pub use super::*;
+pub use super::{Parse, ParsedResponse};
 
 pub use crc::crc32;
 
-//use std::mem;
 use std::mem::transmute;
 
 pub struct Response {
@@ -55,8 +54,7 @@ impl Parse for Response {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
-    use super::*;
+    use super::{Parse, ParsedResponse, Response};
 
     #[test]
     fn test_parse_incomplete() {

--- a/deps/parser/src/memcache.rs
+++ b/deps/parser/src/memcache.rs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
+pub use super::{Parse, ParsedResponse};
 
 pub struct Response {
     pub response: String,
@@ -157,8 +157,7 @@ impl Parse for Response {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
-    use super::*;
+    use super::{Parse, ParsedResponse, Response};
 
     #[test]
     fn test_parse_incomplete() {

--- a/deps/parser/src/ping.rs
+++ b/deps/parser/src/ping.rs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
+pub use super::{Parse, ParsedResponse};
 
 pub struct Response {
     pub response: String,
@@ -59,8 +59,7 @@ impl Parse for Response {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
-    use super::*;
+    use super::{Parse, ParsedResponse, Response};
 
     #[test]
     fn test_parse_pong() {

--- a/deps/parser/src/redis.rs
+++ b/deps/parser/src/redis.rs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
+pub use super::{Parse, ParsedResponse};
 
 pub struct Response {
     pub response: String,
@@ -103,7 +103,7 @@ impl Parse for Response {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Parse, ParsedResponse, Response};
 
     #[test]
     fn test_parse_incomplete() {

--- a/deps/request/Cargo.toml
+++ b/deps/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "request"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/deps/request/src/echo.rs
+++ b/deps/request/src/echo.rs
@@ -15,8 +15,6 @@
 
 extern crate crc;
 
-pub use super::*;
-
 use crc::crc32;
 use std::mem::transmute;
 

--- a/deps/request/src/memcache.rs
+++ b/deps/request/src/memcache.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
-
 /// request to change memcache verbosity
 ///
 /// # Example

--- a/deps/request/src/ping.rs
+++ b/deps/request/src/ping.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
-
 /// ping request
 ///
 /// # Example

--- a/deps/request/src/redis.rs
+++ b/deps/request/src/redis.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use super::*;
-
 /// FLUSHALL request
 ///
 /// # Example

--- a/deps/workload/Cargo.toml
+++ b/deps/workload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workload"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/deps/workload/src/lib.rs
+++ b/deps/workload/src/lib.rs
@@ -23,11 +23,11 @@ extern crate time;
 extern crate rand;
 extern crate shuteye;
 
+use mpmc::Queue as BoundedQueue;
 use rand::{thread_rng, Rng};
 
-use request::*;
-use ratelimit::*;
-use mpmc::Queue as BoundedQueue;
+use ratelimit::Ratelimit;
+use request::{echo, memcache, ping, redis};
 
 const ONE_SECOND: u64 = 1_000_000_000;
 const BUCKET_SIZE: usize = 10_000;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -17,17 +17,17 @@ extern crate mio;
 extern crate time;
 extern crate parser;
 
-use client::Client;
 use bytes::Take;
-use std::io::Cursor;
 use mio::{TryRead, TryWrite};
-use mio::tcp::*;
-use state::State;
-use stats::*;
-use workload::Protocol;
+use mio::tcp::TcpStream;
+use std::io::Cursor;
 use std::sync::mpsc;
 
-use parser::*;
+use client::Client;
+use parser::ParsedResponse;
+use state::State;
+use stats::{Stat, Status};
+use workload::Protocol;
 
 pub struct Connection {
     pub socket: TcpStream,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,7 @@ use config::{BenchmarkConfig, BenchmarkWorkload};
 use connection::Connection;
 use logger::SimpleLogger;
 use net::InternetProtocol;
-use parser::*;
-use stats::*;
+use stats::{Stat, Status};
 use workload::Protocol;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,8 @@ extern crate parser;
 use bytes::{Buf, Take};
 use std::io::Cursor;
 use std::mem;
-use parser::*;
+
+use parser::{Parse, ParsedResponse, echo, memcache, ping, redis};
 use workload::Protocol;
 
 // The current state of the client connection


### PR DESCRIPTION
- remove wildcard use statments, fix #14
- bump parser to 0.1.1
- bump request to 0.1.1
- bump workload to 0.1.2
- bump rpc-perf to 0.1.5
