### PR TITLE
rpc-perf 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "0.1.5"
+version = "0.2.1"
 dependencies = [
  "bytes 0.2.11 (git+https://github.com/carllerche/bytes?branch=v0.2.x)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sample configurations can be found in the `configs` directory of this project. T
 
 ```
 $ ./target/release/rpc-perf --config configs/basic.toml -s 10.0.0.11:11211 -d 60 -w 1
-2016-01-17 20:32:21 INFO  [rpc-perf] rpc-perf 0.1.5 initializing...
+2016-01-17 20:32:21 INFO  [rpc-perf] rpc-perf 0.2.1 initializing...
 2016-01-17 20:32:21 INFO  [rpc-perf] -----
 2016-01-17 20:32:21 INFO  [rpc-perf] Config:
 2016-01-17 20:32:21 INFO  [rpc-perf] Config: Server: 10.0.0.11:11211 Protocol: memcache

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -1,0 +1,17 @@
+[general]
+threads = 1
+connections = 1
+duration = 60
+windows = 0
+protocol = "memcache"
+tcp-nodelay = false
+ipv4 = true
+ipv6 = true
+
+[[workload]]
+name = "get"
+method = "get"
+rate = 0
+bytes = 1
+hit = false
+flush = false

--- a/configs/mixed_workload.toml
+++ b/configs/mixed_workload.toml
@@ -1,8 +1,6 @@
 [general]
 threads = 4
 connections = 25
-interval = 1
-duration = 10
 
 [[workload]]
 name = "set"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,8 @@ pub struct BenchmarkConfig {
     pub windows: usize,
     pub protocol: String,
     pub tcp_nodelay: bool,
+    pub ipv4: bool,
+    pub ipv6: bool,
     pub workloads: Vec<BenchmarkWorkload>,
 }
 
@@ -63,6 +65,8 @@ impl Default for BenchmarkConfig {
             windows: 5,
             protocol: "memcache".to_string(),
             tcp_nodelay: false,
+            ipv4: true,
+            ipv6: true,
             workloads: Vec::new(),
         }
     }
@@ -118,6 +122,18 @@ pub fn load_config(path: String) -> Result<BenchmarkConfig, &'static str> {
                     match general.lookup("tcp-nodelay").and_then(|k| k.as_bool()) {
                         Some(tcp_nodelay) => {
                             config.tcp_nodelay = tcp_nodelay;
+                        }
+                        None => {}
+                    }
+                    match general.lookup("ipv4").and_then(|k| k.as_bool()) {
+                        Some(ipv4) => {
+                            config.ipv4 = ipv4;
+                        }
+                        None => {}
+                    }
+                    match general.lookup("ipv6").and_then(|k| k.as_bool()) {
+                        Some(ipv6) => {
+                            config.ipv6 = ipv6;
                         }
                         None => {}
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,19 +311,33 @@ pub fn main() {
         }
     }
 
-    let mut internet_protocol = InternetProtocol::Any;
+    let mut internet_protocol = InternetProtocol::None;
 
     if matches.opt_present("ipv4") && matches.opt_present("ipv6") {
-        error!("Use only --ipv4 or --ipv6");
-        print_usage(&program, opts);
-        return;
+         error!("Use only --ipv4 or --ipv6");
+         print_usage(&program, opts);
+         return;
     }
     if matches.opt_present("ipv4") {
-        internet_protocol = InternetProtocol::IpV4;
+        config.ipv4 = true;
+        config.ipv6 = false;
     }
     if matches.opt_present("ipv6") {
+        config.ipv4 = false;
+        config.ipv6 = true;
+    }
+    if config.ipv4 && config.ipv6 {
+        internet_protocol = InternetProtocol::Any;
+    } else if config.ipv4 {
+        internet_protocol = InternetProtocol::IpV4;
+    } else if config.ipv6 {
         internet_protocol = InternetProtocol::IpV6;
     }
+    if internet_protocol == InternetProtocol::None {
+        error!("No InternetProtocols remaining! Bad config/options");
+        return;
+    }
+
 
     let evconfig = mio::EventLoopConfig::default();
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -25,6 +25,7 @@ pub enum InternetProtocol {
     IpV4,
     IpV6,
     Any,
+    None,
 }
 
 // custom Debug trait to show protocol name in human form
@@ -34,6 +35,7 @@ impl fmt::Debug for InternetProtocol {
             InternetProtocol::IpV4 => write!(f, "IP::v4"),
             InternetProtocol::IpV6 => write!(f, "IP::v6"),
             InternetProtocol::Any => write!(f, "IP::Any"),
+            InternetProtocol::None => write!(f, "IP::None"),
         }
     }
 }


### PR DESCRIPTION
- allow ipv4/v6 selection through config
- rename basic to mixed_workload
- add default config
- bump version to 0.2.1
