### PR TITLE
rpc-perf 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes 0.2.11 (git+https://github.com/carllerche/bytes?branch=v0.2.x)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9,7 +9,7 @@ dependencies = [
  "mio 0.4.3",
  "mpmc 0.1.1 (git+https://github.com/brayniac/mpmc)",
  "parser 0.1.2",
- "regex 0.1.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "request 0.1.1",
  "shuteye 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -47,10 +47,10 @@ source = "git+https://github.com/carllerche/bytes?branch=v0.2.x#d9eac2502c04ea78
 
 [[package]]
 name = "clock_ticks"
-version = "0.0.5"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -100,7 +100,7 @@ name = "log"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ name = "memchr"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -116,8 +116,8 @@ name = "mio"
 version = "0.4.3"
 dependencies = [
  "bytes 0.2.11 (git+https://github.com/carllerche/bytes?branch=v0.2.x)",
- "clock_ticks 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock_ticks 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.0-pre (git+https://github.com/carllerche/nix-rust)",
  "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -132,10 +132,10 @@ source = "git+https://github.com/brayniac/mpmc#9354a419b194a483015b3e51fbafaf05c
 [[package]]
 name = "nix"
 version = "0.5.0-pre"
-source = "git+https://github.com/carllerche/nix-rust#9cdc0d511d9f2e261367124a24ed4bdc38b5ad06"
+source = "git+https://github.com/carllerche/nix-rust#7502db05f562daac1e353fd51d9072b81571f8fb"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -167,10 +167,10 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -217,7 +217,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -234,7 +234,7 @@ name = "winapi"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Sample configurations can be found in the `configs` directory of this project. T
 ./target/release/rpc-perf --server 127.0.0.1:6379 --protocol redis --method get --hit --rate 50000
 
 # run the same test against memcache and redis
-./target/release/rpc-perf --config configs/basic.toml --server 127.0.0.1:11211 --protocol memcache
-./target/release/rpc-perf --config configs/basic.toml --server 127.0.0.1:6379 --protocol redis
+./target/release/rpc-perf --config configs/default.toml --server 127.0.0.1:11211 --protocol memcache
+./target/release/rpc-perf --config configs/default.toml --server 127.0.0.1:6379 --protocol redis
 ```
 
 ## Sample Output
 
 ```
-$ ./target/release/rpc-perf --config configs/basic.toml -s 10.0.0.11:11211 -d 60 -w 1
+$ ./target/release/rpc-perf --config configs/default.toml -s 10.0.0.11:11211 -d 60 -w 1
 2016-01-17 20:32:21 INFO  [rpc-perf] rpc-perf 0.2.1 initializing...
 2016-01-17 20:32:21 INFO  [rpc-perf] -----
 2016-01-17 20:32:21 INFO  [rpc-perf] Config:
@@ -97,7 +97,7 @@ $ ./target/release/rpc-perf --config configs/basic.toml -s 10.0.0.11:11211 -d 60
 
 * Start with a short test before moving on to tests spanning larger periods of time `--duration 1 --windows 1` makes for a quick smoke test
 * When benchmarking for peak throughput, be sure to run enough workers with enough connections to keep them busy sending requests and reading responses. With too few threads, latency will impact throughput. With too many threads, the clients might starve for CPU
-* When benchmarking for latency, be sure to ratelimit and compare across a variety of rates. Use `--duration 60` to latch the histogram at one minute intervals to match up with clients which report percentiles
+* When benchmarking for latency, be sure to ratelimit and compare across a variety of rates. Use `--duration 60` (the default) to latch the histogram at one minute intervals to match up with clients which report percentiles
 * Log your configuration and results, this will help you repeat the experiment and compare results reliably
 
 ## Features

--- a/deps/mio/Cargo.toml
+++ b/deps/mio/Cargo.toml
@@ -19,10 +19,10 @@ exclude       = [
 
 [dependencies]
 log   = "0.3.1"
-libc  = "0.1.8"
+libc  = "0.2.6"
 slab  = "0.1.0"
 winapi = "0.1.23"
-clock_ticks = "0.0.5"
+clock_ticks = "0.1.0"
 
 [dependencies.nix]
 git = "https://github.com/carllerche/nix-rust"

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,7 +415,7 @@ pub fn main() {
     }
 
     let mut histogram_config = HistogramConfig::new();
-    histogram_config.precision(4).max_value(ONE_SECOND as u64);
+    histogram_config.precision(4).max_value(60 * ONE_SECOND as u64);
     let mut histogram = Histogram::configured(histogram_config).unwrap();
 
     let mut trace_config = HistogramConfig::new();


### PR DESCRIPTION
- increate histogram capacity for 1 minute latencies
- update dependencies
- bump version 0.2.2
- readme updates
