### PR TITLE
Parsing does dramatically less copying

### DIFF
--- a/lib/parser/src/echo.rs
+++ b/lib/parser/src/echo.rs
@@ -21,11 +21,11 @@ pub use crc::crc32;
 
 use std::mem::transmute;
 
-pub struct Response {
-    pub response: Vec<u8>,
+pub struct Response<'a> {
+    pub response: &'a [u8],
 }
 
-impl Parse for Response {
+impl<'a> Parse for Response<'a> {
     fn parse(&self) -> ParsedResponse {
 
         if self.response.len() <= 6 {
@@ -58,25 +58,25 @@ mod tests {
 
     #[test]
     fn test_parse_incomplete() {
-        let r = Response { response: vec![0] };
+        let r = Response { response: &[0] };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
 
-        let r = Response { response: vec![0, 1, 2, 3, 4, 5, 6] };
+        let r = Response { response: &[0, 1, 2, 3, 4, 5, 6] };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
 
-        let r = Response { response: vec![0, 1, 2, 3, 4, 5, 6, 13] };
+        let r = Response { response: &[0, 1, 2, 3, 4, 5, 6, 13] };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
     }
 
     #[test]
     fn test_parse_ok() {
-        let r = Response { response: vec![0, 1, 2, 8, 84, 137, 127, 13, 10] };
+        let r = Response { response: &[0, 1, 2, 8, 84, 137, 127, 13, 10] };
         assert_eq!(r.parse(), ParsedResponse::Ok);
     }
 
     #[test]
     fn test_parse_error() {
-        let r = Response { response: "3421780262\r\n".to_string().into_bytes() };
+        let r = Response { response: "3421780262\r\n".as_bytes() };
         assert_eq!(r.parse(), ParsedResponse::Error("bad crc".to_string()));
     }
 }

--- a/lib/parser/src/ping.rs
+++ b/lib/parser/src/ping.rs
@@ -15,11 +15,11 @@
 
 pub use super::{Parse, ParsedResponse};
 
-pub struct Response {
-    pub response: String,
+pub struct Response<'a> {
+    pub response: &'a str,
 }
 
-impl Parse for Response {
+impl<'a> Parse for Response<'a> {
     fn parse(&self) -> ParsedResponse {
 
         let mut lines: Vec<&str> = self.response.split("\r\n").collect();
@@ -63,13 +63,13 @@ mod tests {
 
     #[test]
     fn test_parse_pong() {
-        let r = Response { response: "PONG".to_string() };
+        let r = Response { response: "PONG" };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
 
-        let r = Response { response: "PONG\r\n".to_string() };
+        let r = Response { response: "PONG\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Ok);
 
-        let r = Response { response: "ERROR\r\n".to_string() };
+        let r = Response { response: "ERROR\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Unknown);
     }
 }

--- a/lib/parser/src/redis.rs
+++ b/lib/parser/src/redis.rs
@@ -15,11 +15,11 @@
 
 pub use super::{Parse, ParsedResponse};
 
-pub struct Response {
-    pub response: String,
+pub struct Response<'a> {
+    pub response: &'a str,
 }
 
-impl Parse for Response {
+impl<'a> Parse for Response<'a> {
     fn parse(&self) -> ParsedResponse {
 
         let mut lines: Vec<&str> = self.response.split("\r\n").collect();
@@ -86,56 +86,56 @@ mod tests {
 
     #[test]
     fn test_parse_incomplete() {
-        let r = Response { response: "+OK".to_string() };
+        let r = Response { response: "+OK" };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
 
-        let r = Response { response: "+OK\r".to_string() };
+        let r = Response { response: "+OK\r" };
         assert_eq!(r.parse(), ParsedResponse::Incomplete);
     }
 
     #[test]
     fn test_parse_invalid() {
-        let r = Response { response: "?OK\r\n".to_string() };
+        let r = Response { response: "?OK\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Invalid);
 
-        let r = Response { response: ":OK\r\n".to_string() };
+        let r = Response { response: ":OK\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Invalid);
     }
 
     #[test]
     fn test_parse_ok() {
-        let r = Response { response: "+OK\r\n".to_string() };
+        let r = Response { response: "+OK\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Ok);
 
-        let r = Response { response: "$0\r\n\r\n".to_string() };
+        let r = Response { response: "$0\r\n\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Hit);
 
-        let r = Response { response: "$1\r\n1\r\n".to_string() };
+        let r = Response { response: "$1\r\n1\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Hit);
 
-        let r = Response { response: ":12345\r\n".to_string() };
+        let r = Response { response: ":12345\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Ok);
 
-        let r = Response { response: ":-12345\r\n".to_string() };
+        let r = Response { response: ":-12345\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Ok);
     }
 
     #[test]
     fn test_parse_error() {
-        let r = Response { response: "-ERROR\r\n".to_string() };
+        let r = Response { response: "-ERROR\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Error("ERROR".to_string()));
 
-        let r = Response { response: "-ERROR with message\r\n".to_string() };
+        let r = Response { response: "-ERROR with message\r\n" };
         assert_eq!(r.parse(),
                    ParsedResponse::Error("ERROR with message".to_string()));
     }
 
     #[test]
     fn test_parse_miss() {
-        let r = Response { response: "$-1\r\n".to_string() };
+        let r = Response { response: "$-1\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Miss);
 
-        let r = Response { response: "*-1\r\n".to_string() };
+        let r = Response { response: "*-1\r\n" };
         assert_eq!(r.parse(), ParsedResponse::Miss);
     }
 }

--- a/lib/parser/src/thrift.rs
+++ b/lib/parser/src/thrift.rs
@@ -17,11 +17,11 @@ pub use super::{Parse, ParsedResponse};
 
 use byteorder::{ByteOrder, BigEndian};
 
-pub struct Response {
-    pub response: Vec<u8>,
+pub struct Response<'a> {
+    pub response: &'a [u8],
 }
 
-impl Parse for Response {
+impl<'a> Parse for Response<'a> {
     fn parse(&self) -> ParsedResponse {
         let bytes = self.response.len();
         if bytes > 4 {
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_parse_ok() {
-        assert_eq!(Response { response: vec![0, 0, 0, 1, 0] }.parse(), ParsedResponse::Ok);
-        assert_eq!(Response { response: vec![0, 0, 0, 2, 0, 1] }.parse(), ParsedResponse::Ok);
+        assert_eq!(Response { response: &[0, 0, 0, 1, 0] }.parse(), ParsedResponse::Ok);
+        assert_eq!(Response { response: &[0, 0, 0, 2, 0, 1] }.parse(), ParsedResponse::Ok);
     }
 }


### PR DESCRIPTION
The actual parsing process doesn't need a unique copy of the buffer so it can actually be shared safely. Places that required a moved Vec<u8> can now take a &[u8] and places that required a moved String now take a &str, all of which are just views of the ByteBuf contents.