### PR TITLE
thrift request refactoring

### DIFF
--- a/lib/parser/src/thrift.rs
+++ b/lib/parser/src/thrift.rs
@@ -44,4 +44,11 @@ mod tests {
         assert_eq!(Response { response: &[0, 0, 0, 1, 0] }.parse(), ParsedResponse::Ok);
         assert_eq!(Response { response: &[0, 0, 0, 2, 0, 1] }.parse(), ParsedResponse::Ok);
     }
+
+    #[test]
+    fn test_parse_incomplete() {
+        assert_eq!(Response { response: &[0, 0] }.parse(), ParsedResponse::Incomplete);
+        assert_eq!(Response { response: &[0, 0, 0, 1] }.parse(), ParsedResponse::Incomplete);
+        assert_eq!(Response { response: &[0, 0, 0, 2, 0] }.parse(), ParsedResponse::Incomplete);
+    }
 }


### PR DESCRIPTION
Refactored the thrift request lib to follow the builder pattern. This should make it more flexible short-term for supporting more complex requests. This change also removes the right-shift of the buffer when framing the request