### PR TITLE
workload refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "workload 0.1.3",
+ "workload 0.2.0",
 ]
 
 [[package]]
@@ -215,6 +215,14 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pad"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parser"
 version = "0.1.4"
 dependencies = [
@@ -324,6 +332,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,10 +364,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "workload"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.1 (git+https://github.com/brayniac/mpmc)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimit 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "request 0.1.2",

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -1,8 +1,13 @@
+# this example is the default behavior of rpc-perf
+# non-ratelimitied hotkey get suitable for memcache or redis on a 1byte key
+#
+# use-case: measure the peak get rate for a single connection with minimal payload
+
 [general]
 threads = 1
 connections = 1
 duration = 60
-windows = 0
+windows = 5
 protocol = "memcache"
 tcp-nodelay = false
 ipv4 = true
@@ -12,6 +17,7 @@ ipv6 = true
 name = "get"
 method = "get"
 rate = 0
-bytes = 1
-hit = false
-flush = false
+  [[workload.parameter]]
+  style = "static"
+  size = 1
+  seed = 0

--- a/configs/hotkey_hit.toml
+++ b/configs/hotkey_hit.toml
@@ -1,0 +1,26 @@
+# this example is the default behavior of rpc-perf
+# non-ratelimitied hotkey get suitable for memcache or redis on a 1byte key
+#
+# use-case: benchmark peak throughput for 128b value (hitrate: 100%)
+
+[[workload]]
+name = "get"
+method = "get"
+rate = 0
+  [[workload.parameter]]
+  style = "static"
+  size = 1
+  seed = 0
+
+[[workload]]
+name = "set"
+method = "set"
+rate = 1
+  [[workload.parameter]]
+  style = "static"
+  size = 1
+  seed = 0
+  [[workload.parameter]]
+  style = "random"
+  size = 128
+  regenerate = false

--- a/configs/mixed_workload.toml
+++ b/configs/mixed_workload.toml
@@ -1,14 +1,25 @@
-[general]
-threads = 4
-connections = 25
+# this example runs a mixed key-value workload suitable for memcache and redis
+# gets and sets occur on a 3byte keyspace with set injecting 4 byte values
+# read/write 80%/20% at 50kqps aggregate
+
+[[workload]]
+name = "get"
+method = "get"
+rate = 40000
+  [[workload.parameter]]
+  style = "random"
+  size = 3
+  regenerate = true
 
 [[workload]]
 name = "set"
 method = "set"
 rate = 10000
-
-[[workload]]
-name = "get"
-method = "get"
-hit = true
-rate = 50000
+  [[workload.parameter]]
+  style = "random"
+  size = 3
+  regenerate = true
+  [[workload.parameter]]
+  style = "random"
+  size = 4
+  regenerate = false

--- a/lib/request/src/echo.rs
+++ b/lib/request/src/echo.rs
@@ -24,9 +24,8 @@ use std::mem::transmute;
 /// ```
 /// # use request::echo::*;
 ///
-/// assert_eq!(echo("123456789"), [49, 50, 51, 52, 53, 54, 55, 56, 57, 203, 244, 57, 38, 13, 10]);
-pub fn echo(v: &str) -> Vec<u8> {
-    let value = v.as_bytes();
+/// assert_eq!(echo(b"123456789"), [49, 50, 51, 52, 53, 54, 55, 56, 57, 203, 244, 57, 38, 13, 10]);
+pub fn echo(value: &[u8]) -> Vec<u8> {
     let crc = crc32::checksum_ieee(value);
     let mut msg: Vec<u8> = Vec::new();
     msg.extend(value.iter().cloned());

--- a/lib/workload/Cargo.toml
+++ b/lib/workload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workload"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "apache-2.0"
@@ -13,6 +13,7 @@ time = "0.1.34"
 rand = "0.3.14"
 ratelimit = "0.2.2"
 shuteye = "0.1.0"
+pad = "0.1.4"
 
 [dependencies.mpmc]
 git = "https://github.com/brayniac/mpmc"

--- a/lib/workload/src/lib.rs
+++ b/lib/workload/src/lib.rs
@@ -17,20 +17,22 @@
 #![crate_name = "workload"]
 
 extern crate mpmc;
+extern crate pad;
 extern crate request;
 extern crate ratelimit;
 extern crate time;
 extern crate rand;
 extern crate shuteye;
 
-use mpmc::Queue as BoundedQueue;
-use rand::{thread_rng, Rng};
+const ONE_SECOND: u64 = 1_000_000_000;
+pub const BUCKET_SIZE: usize = 10_000;
 
+use mpmc::Queue as BoundedQueue;
+use pad::{PadStr, Alignment};
+use rand::{thread_rng, Rng};
 use ratelimit::Ratelimit;
 use request::{echo, memcache, ping, redis, thrift};
-
-const ONE_SECOND: u64 = 1_000_000_000;
-const BUCKET_SIZE: usize = 10_000;
+use std::str;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Protocol {
@@ -43,43 +45,19 @@ pub enum Protocol {
 }
 
 impl Protocol {
-    pub fn new(protocol: &str) -> Result<Protocol, ()> {
+    pub fn new(protocol: &str) -> Result<Protocol, &'static str> {
         match &*protocol {
-            "echo" => {
-                return Ok(Protocol::Echo);
-            }
-            "memcache" => {
-                return Ok(Protocol::Memcache);
-            }
-            "ping" => {
-                return Ok(Protocol::Ping);
-            }
-            "redis" => {
-                return Ok(Protocol::Redis);
-            }
-            "thrift" => {
-                return Ok(Protocol::Thrift);
-            }
-            _ => {
-                return Err(());
-            }
+            "echo" => Ok(Protocol::Echo),
+            "memcache" => Ok(Protocol::Memcache),
+            "ping" => Ok(Protocol::Ping),
+            "redis" => Ok(Protocol::Redis),
+            "thrift" => Ok(Protocol::Thrift),
+            _ => Err("unknown protocol"),
         }
     }
 }
 
-pub struct Hotkey {
-    id: usize,
-    protocol: Protocol,
-    command: String,
-    ratelimit: Ratelimit,
-    rate: u64,
-    queue: BoundedQueue<Vec<u8>>,
-    length: usize,
-    hit: bool,
-    flush: bool,
-}
-
-fn rate_to_interval(rate: u64) -> u64 {
+pub fn rate_to_interval(rate: u64) -> u64 {
     if rate == 0 {
         return 0;
     }
@@ -90,174 +68,234 @@ fn rate_to_interval(rate: u64) -> u64 {
     interval
 }
 
-impl Hotkey {
-    pub fn new(id: usize,
-               protocol: String,
+fn random_string(size: usize) -> String {
+    thread_rng().gen_ascii_chars().take(size).collect()
+}
+
+fn seeded_string(size: usize, seed: usize) -> String {
+    let s = format!("{}", seed);
+    s.pad(size, '0', Alignment::Right, true)
+}
+
+#[derive(Clone, Debug)]
+pub enum Parameter {
+    Random {
+        size: usize,
+        regenerate: bool,
+    }, // random first or everytime
+    Static {
+        size: usize,
+        seed: usize,
+    }, // fixed based on some seed
+}
+
+impl Default for Parameter {
+    fn default() -> Parameter {
+        Parameter::Static { size: 1, seed: 0 }
+    }
+}
+
+pub enum Preparation {
+    Flush,
+    Hit,
+}
+
+pub struct Workload {
+    protocol: Protocol,
+    command: String,
+    rate: u64,
+    ratelimit: Ratelimit,
+    queue: BoundedQueue<Vec<u8>>,
+    parameters: Vec<Parameter>,
+    values: Vec<Vec<u8>>,
+}
+
+impl Workload {
+    pub fn new(protocol: Protocol,
                command: String,
-               length: usize,
-               rate: u64,
-               queue: BoundedQueue<Vec<u8>>,
-               quantum: usize,
-               hit: bool,
-               flush: bool)
-               -> Result<Hotkey, &'static str> {
-
-        let cmd = command.clone();
-        let proto: Protocol;
-
-        match Protocol::new(&protocol) {
-            Ok(p) => {
-                proto = p;
-            }
-            Err(..) => {
-                panic!("Bad protocol: {}", protocol);
-            }
-        }
-
-        let interval = rate_to_interval(rate);
-        match Ratelimit::new(BUCKET_SIZE, time::precise_time_ns(), interval, quantum) {
-            Some(r) => {
-                return Ok(Hotkey {
-                    id: id,
-                    protocol: proto,
-                    command: cmd,
-                    length: length,
-                    rate: rate,
-                    ratelimit: r,
-                    queue: queue,
-                    hit: hit,
-                    flush: flush,
-                });
-            }
+               rate: Option<u64>,
+               queue: BoundedQueue<Vec<u8>>)
+               -> Result<Workload, &'static str> {
+        let r = rate.unwrap_or(0);
+        let i = rate_to_interval(r);
+        let ratelimit = match Ratelimit::new(BUCKET_SIZE, time::precise_time_ns(), i, 1) {
+            Some(r) => r,
             None => {
-                return Err("Ratelimit::new() returned None");
+                return Err("Ratelimit initialization failed!");
+            }
+        };
+        Ok(Workload {
+            protocol: protocol,
+            command: command,
+            rate: rate.unwrap_or(0),
+            ratelimit: ratelimit,
+            queue: queue,
+            parameters: Vec::<Parameter>::new(),
+            values: Vec::<Vec<u8>>::new(),
+        })
+    }
+
+    fn generate_values(&mut self, force: bool) {
+        for i in 0..self.parameters.len() {
+            match self.parameters[i] {
+                Parameter::Random { size, regenerate } => {
+                    if regenerate || force {
+                        self.values[i] = random_string(size).into_bytes();
+                    }
+                }
+                Parameter::Static { size, seed } => {
+                    self.values[i] = seeded_string(size, seed).into_bytes();
+                }
             }
         }
     }
 
-    fn random_value(length: usize) -> String {
-        thread_rng().gen_ascii_chars().take(length).collect()
+    pub fn add_param(&mut self, parameter: Parameter) {
+        self.parameters.push(parameter);
+        self.values.push(Vec::<u8>::new());
+    }
+
+    pub fn prepare(&mut self, preparation: Preparation) {
+        match preparation {
+            Preparation::Flush => {
+                match self.protocol {
+                    Protocol::Memcache => {
+                        let _ = self.queue.push(memcache::flush_all().into_bytes());
+                    }
+                    Protocol::Redis => {
+                        let _ = self.queue.push(redis::flushall().into_bytes());
+                    }
+                    _ => {}
+                }
+            }
+            Preparation::Hit => {
+                match &*self.command {
+                    "get" => {
+                        match self.protocol {
+                            Protocol::Memcache => {
+                                if self.values.len() < 2 {
+                                    self.values.push(Default::default());
+                                }
+                                let _ = self.queue
+                                            .push(memcache::set(str::from_utf8(&*self.values[0])
+                                                                    .unwrap(),
+                                                                str::from_utf8(&*self.values[1])
+                                                                    .unwrap(),
+                                                                None,
+                                                                None)
+                                                      .into_bytes());
+                            }
+                            Protocol::Redis => {
+                                let _ = self.queue.push(redis::flushall().into_bytes());
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
 
     pub fn run(&mut self) {
-        // calculate the query
-
-        let query: Vec<u8>;
-
-        let key = format!("{}", self.id);
-
-        let value = Self::random_value(self.length);
-
-        match self.protocol {
-            Protocol::Memcache => {
-                if self.flush {
-                    let flush = memcache::flush_all().into_bytes();
-                    let _ = self.queue.push(flush);
-                    shuteye::sleep(shuteye::Timespec::from_nano(1_000_000 as i64).unwrap());
-                }
-                match &*self.command {
-                    "set" => {
-                        query = memcache::set(&key, &*value, None, None).into_bytes();
-                    }
-                    "get" => {
-                        if self.hit {
-                            let prepare = memcache::set(&key, &*value, None, None).into_bytes();
-                            for _ in 0..5 {
-                                let _ = self.queue.push(prepare.clone());
-                            }
-                            shuteye::sleep(shuteye::Timespec::from_nano(1_000_000 as i64).unwrap());
-                        }
-                        query = memcache::get(&key).into_bytes();
-                    }
-                    _ => {
-                        panic!("unknown command: {} for protocol: {:?}",
-                               self.command,
-                               self.protocol);
-                    }
-                }
-            }
-            Protocol::Ping => {
-                match &*self.command {
-                    "ping" => {
-                        query = ping::ping().into_bytes();
-                    }
-                    _ => {
-                        panic!("unknown command: {} for protocol: {:?}",
-                               self.command,
-                               self.protocol);
-                    }
-                }
-            }
-            Protocol::Redis => {
-                if self.flush {
-                    let flush = redis::flushall().into_bytes();
-                    let _ = self.queue.push(flush);
-                }
-                match &*self.command {
-                    "set" => {
-                        query = redis::set(&key, &*value).into_bytes();
-                    }
-                    "get" => {
-                        if self.hit {
-                            let prepare = redis::set(&key, &*value).into_bytes();
-                            let _ = self.queue.push(prepare);
-                        }
-                        query = redis::get(&key).into_bytes();
-                    }
-                    "hset" => {
-                        query = redis::hset(&key, "key", &*value).into_bytes();
-                    }
-                    "hget" => {
-                        if self.hit {
-                            let prepare = redis::hset(&key, "key", &*value).into_bytes();
-                            let _ = self.queue.push(prepare);
-                        }
-                        query = redis::hget(&key, "key").into_bytes();
-                    }
-                    _ => {
-                        panic!("unknown command: {} for protocol: {:?}",
-                               self.command,
-                               self.protocol);
-                    }
-                }
-            }
-            Protocol::Echo => {
-                match &*self.command {
-                    "echo" => {
-                        query = echo::echo(&*value);
-                    }
-                    _ => {
-                        panic!("unknown command: {} for protocol: {:?}",
-                               self.command,
-                               self.protocol);
-                    }
-                }
-            }
-            Protocol::Thrift => {
-                match &*self.command {
-                    "ping" => {
-                        query = thrift::ping();
-                    }
-                    _ => {
-                        panic!("unknown command: {} for protocol: {:?}",
-                               self.command,
-                               self.protocol);
-                    }
-                }
-            }
-            Protocol::Unknown => panic!("unknown protocol"),
-        }
-
-        // critical sections
-        if self.rate == 0 {
-            loop {
-                let _ = self.queue.push(query.clone());
-            }
-        } else {
-            loop {
+        self.generate_values(true);
+        loop {
+            if self.rate != 0 {
                 self.ratelimit.block(1);
-                let _ = self.queue.push(query.clone());
             }
+            self.generate_values(false);
+
+            let query = match self.protocol {
+                Protocol::Echo => {
+                    match &*self.command {
+                        "echo" => echo::echo(&*self.values[0]),
+                        _ => {
+                            panic!("unknown command: {} for protocol: {:?}",
+                                   self.command,
+                                   self.protocol);
+                        }
+                    }
+                }
+                Protocol::Memcache => {
+                    match &*self.command {
+                        "set" => {
+                            memcache::set(str::from_utf8(&*self.values[0]).unwrap(),
+                                          str::from_utf8(&*self.values[1]).unwrap(),
+                                          None,
+                                          None)
+                                .into_bytes()
+                        }
+                        "get" => {
+                            memcache::get(str::from_utf8(&*self.values[0]).unwrap()).into_bytes()
+                        }
+                        "gets" => {
+                            memcache::gets(str::from_utf8(&*self.values[0]).unwrap()).into_bytes()
+                        }
+                        "add" => {
+                            memcache::add(str::from_utf8(&*self.values[0]).unwrap(),
+                                          str::from_utf8(&*self.values[1]).unwrap(),
+                                          None,
+                                          None)
+                                .into_bytes()
+                        }
+                        _ => {
+                            panic!("unknown command: {} for protocol: {:?}",
+                                   self.command,
+                                   self.protocol);
+                        }
+                    }
+                }
+                Protocol::Ping => {
+                    match &*self.command {
+                        "ping" => ping::ping().into_bytes(),
+                        _ => {
+                            panic!("unknown command: {} for protocol: {:?}",
+                                   self.command,
+                                   self.protocol);
+                        }
+                    }
+                }
+                Protocol::Redis => {
+                    match &*self.command {
+                        "set" => {
+                            redis::set(str::from_utf8(&*self.values[0]).unwrap(),
+                                       str::from_utf8(&*self.values[1]).unwrap())
+                                .into_bytes()
+                        }
+                        "get" => redis::get(str::from_utf8(&*self.values[0]).unwrap()).into_bytes(),
+                        "hset" => {
+                            redis::hset(str::from_utf8(&*self.values[0]).unwrap(),
+                                        str::from_utf8(&*self.values[1]).unwrap(),
+                                        str::from_utf8(&*self.values[2]).unwrap())
+                                .into_bytes()
+                        }
+                        "hget" => {
+                            redis::hget(str::from_utf8(&*self.values[0]).unwrap(),
+                                        str::from_utf8(&*self.values[1]).unwrap())
+                                .into_bytes()
+                        }
+                        _ => {
+                            panic!("unknown command: {} for protocol: {:?}",
+                                   self.command,
+                                   self.protocol);
+                        }
+                    }
+                }
+                Protocol::Thrift => {
+                    match &*self.command {
+                        "ping" => thrift::ping(),
+                        _ => {
+                            panic!("unknown command: {} for protocol: {:?}",
+                                   self.command,
+                                   self.protocol);
+                        }
+                    }
+                }
+                _ => {
+                    panic!("unsupported protocol");
+                }
+            };
+            let _ = self.queue.push(query.clone());
         }
     }
 }


### PR DESCRIPTION
- breaking: removes cli workload support
- adds parameters as part of workload spec
- allows for random key / value geneneration - fixes #41
- extend config to allow specifying parameters for workload
- update example configs with new format
- bump workload to 0.2.0