### PR TITLE
prepare for publish on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-nightly"
+version = "1.0.0-nightly.20160324"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8,16 +8,16 @@ dependencies = [
  "histogram 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpmc 0.1.1 (git+https://github.com/brayniac/mpmc)",
- "parser 0.1.4",
- "regex 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "request 0.1.2",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_parser 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_request 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_workload 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "workload 0.2.1",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ name = "kernel32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -157,11 +157,11 @@ dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -170,25 +170,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mpmc"
-version = "0.1.1"
-source = "git+https://github.com/brayniac/mpmc#9354a419b194a483015b3e51fbafaf05c24d4b24"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -223,15 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parser"
-version = "0.1.4"
-dependencies = [
- "byteorder 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -265,11 +256,37 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "request"
-version = "0.1.2"
+name = "rpcperf_parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rpcperf_request"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rpcperf_workload"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratelimit 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_request 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,7 +337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -363,25 +380,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "workload"
-version = "0.2.1"
-dependencies = [
- "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpmc 0.1.1 (git+https://github.com/brayniac/mpmc)",
- "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "ratelimit 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "request 0.1.2",
- "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rpc-perf"
-version = "1.0.0-nightly"
+version = "1.0.0-nightly.20160324"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-license = "apache-2.0"
+license = "Apache-2.0"
 
 description = "RPC Performance Testing"
 
-homepage = ""
-repository = ""
+homepage = "https://github.com/twitter/rpc-perf"
+repository = "https://github.com/twitter/rpc-perf"
 
 readme = "README.md"
 
@@ -35,21 +35,13 @@ heatmap = "0.1.7"
 histogram = "0.3.6"
 log = "0.3.5"
 mio = "0.5.0"
+mpmc = "0.1.2"
 regex = "0.1.41"
+rpcperf_parser = "1.0.0"
+rpcperf_request = "1.0.0"
+rpcperf_workload = "1.0.0"
 shuteye = "0.1.1"
 simple_logger = "0.4.0"
 time = "0.1.34"
 toml = "0.1.27"
 waterfall = "0.1.4"
-
-[dependencies.mpmc]
-git = "https://github.com/brayniac/mpmc"
-
-[dependencies.parser]
-path = "./lib/parser/"
-
-[dependencies.request]
-path = "./lib/request/"
-
-[dependencies.workload]
-path = "./lib/workload/"

--- a/lib/parser/Cargo.toml
+++ b/lib/parser/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
-name = "parser"
-version = "0.1.4"
+name = "rpcperf_parser"
+version = "1.0.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-license = "apache-2.0"
+license = "Apache-2.0"
 
 description = "rpc-perf response parsers"
+
+homepage = "https://github.com/twitter/rpc-perf"
+repository = "https://github.com/twitter/rpc-perf"
+
+readme = "README.md"
 
 [dependencies]
 log = "0.3.5"

--- a/lib/parser/README.md
+++ b/lib/parser/README.md
@@ -1,0 +1,3 @@
+# rpcperf_parser - parsing responses for rpc-perf
+
+This crate is intended for use by rpc-perf for parsing responses to requests.

--- a/lib/parser/src/lib.rs
+++ b/lib/parser/src/lib.rs
@@ -14,7 +14,6 @@
 //  limitations under the License.
 
 #![crate_type = "lib"]
-#![crate_name = "parser"]
 
 #[macro_use]
 extern crate log;

--- a/lib/request/Cargo.toml
+++ b/lib/request/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
-name = "request"
-version = "0.1.2"
+name = "rpcperf_request"
+version = "1.0.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-license = "apache-2.0"
+license = "Apache-2.0"
 
 description = "rpc-perf request builder"
+
+homepage = "https://github.com/twitter/rpc-perf"
+repository = "https://github.com/twitter/rpc-perf"
+
+readme = "README.md"
 
 [dependencies]
 byteorder = "0.5.0"

--- a/lib/request/README.md
+++ b/lib/request/README.md
@@ -1,0 +1,3 @@
+# rpcperf_request - building requests for rpc-perf
+
+This crate is intended for use by rpc-perf for generating on-wire format for requests.

--- a/lib/request/src/echo.rs
+++ b/lib/request/src/echo.rs
@@ -22,7 +22,7 @@ use std::mem::transmute;
 ///
 /// # Example
 /// ```
-/// # use request::echo::*;
+/// # use rpcperf_request::echo::*;
 ///
 /// assert_eq!(echo(b"123456789"), [49, 50, 51, 52, 53, 54, 55, 56, 57, 203, 244, 57, 38, 13, 10]);
 pub fn echo(value: &[u8]) -> Vec<u8> {

--- a/lib/request/src/lib.rs
+++ b/lib/request/src/lib.rs
@@ -14,7 +14,6 @@
 //  limitations under the License.
 
 #![crate_type = "lib"]
-#![crate_name = "request"]
 
 extern crate byteorder;
 extern crate crc;

--- a/lib/request/src/memcache.rs
+++ b/lib/request/src/memcache.rs
@@ -17,7 +17,7 @@
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(verbosity(4), "verbosity 4\r\n");
 pub fn verbosity(level: usize) -> String {
@@ -28,7 +28,7 @@ pub fn verbosity(level: usize) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(version(), "version\r\n");
 pub fn version() -> String {
@@ -39,7 +39,7 @@ pub fn version() -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(quit(), "quit\r\n");
 pub fn quit() -> String {
@@ -50,7 +50,7 @@ pub fn quit() -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(set("key", "value", None, None), "set key 0 0 5\r\nvalue\r\n");
 pub fn set(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> String {
@@ -68,7 +68,7 @@ pub fn set(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> 
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(cas("key", "value", None, None, 100_u64), "cas key 0 0 5 100\r\nvalue\r\n");
 pub fn cas(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>, cas: u64) -> String {
@@ -87,7 +87,7 @@ pub fn cas(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>, cas
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(add("key", "value", None, None), "add key 0 0 5\r\nvalue\r\n");
 pub fn add(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> String {
@@ -105,7 +105,7 @@ pub fn add(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> 
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(replace("key", "value", None, None), "replace key 0 0 5\r\nvalue\r\n");
 pub fn replace(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> String {
@@ -123,7 +123,7 @@ pub fn replace(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>)
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(append("key", "value", None, None), "append key 0 0 5\r\nvalue\r\n");
 pub fn append(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> String {
@@ -141,7 +141,7 @@ pub fn append(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) 
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(prepend("key", "value", None, None), "prepend key 0 0 5\r\nvalue\r\n");
 pub fn prepend(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>) -> String {
@@ -159,7 +159,7 @@ pub fn prepend(key: &str, value: &str, exptime: Option<u32>, flags: Option<u32>)
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(incr("key", 1), "incr key 1\r\n");
 /// assert_eq!(incr("key", 1000), "incr key 1000\r\n");
@@ -171,7 +171,7 @@ pub fn incr(key: &str, value: u64) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(decr("key", 1), "decr key 1\r\n");
 /// assert_eq!(decr("key", 1000), "decr key 1000\r\n");
@@ -183,7 +183,7 @@ pub fn decr(key: &str, value: u64) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(touch("key", None), "touch key 0\r\n");
 pub fn touch(key: &str, exptime: Option<u32>) -> String {
@@ -195,7 +195,7 @@ pub fn touch(key: &str, exptime: Option<u32>) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(get("key"), "get key\r\n");
 pub fn get(key: &str) -> String {
@@ -206,7 +206,7 @@ pub fn get(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(gets("key"), "gets key\r\n");
 pub fn gets(key: &str) -> String {
@@ -217,7 +217,7 @@ pub fn gets(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(delete("key"), "delete key\r\n");
 pub fn delete(key: &str) -> String {
@@ -228,7 +228,7 @@ pub fn delete(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::memcache::*;
+/// # use rpcperf_request::memcache::*;
 ///
 /// assert_eq!(flush_all(), "flush_all\r\n");
 pub fn flush_all() -> String {

--- a/lib/request/src/ping.rs
+++ b/lib/request/src/ping.rs
@@ -17,7 +17,7 @@
 ///
 /// # Example
 /// ```
-/// # use request::ping::*;
+/// # use rpcperf_request::ping::*;
 ///
 /// assert_eq!(ping(), "PING\r\n");
 pub fn ping() -> String {

--- a/lib/request/src/redis.rs
+++ b/lib/request/src/redis.rs
@@ -17,7 +17,7 @@
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(flushall(), "flushall\r\n");
 pub fn flushall() -> String {
@@ -28,7 +28,7 @@ pub fn flushall() -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(set("key", "value"), "set key value\r\n");
 pub fn set(key: &str, value: &str) -> String {
@@ -39,7 +39,7 @@ pub fn set(key: &str, value: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(hset("hash", "key", "value"), "hset hash key value\r\n");
 pub fn hset(hash: &str, key: &str, value: &str) -> String {
@@ -50,7 +50,7 @@ pub fn hset(hash: &str, key: &str, value: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(get("key"), "get key\r\n");
 pub fn get(key: &str) -> String {
@@ -61,7 +61,7 @@ pub fn get(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(hget("hash", "key"), "hget hash key\r\n");
 pub fn hget(hash: &str, key: &str) -> String {
@@ -72,7 +72,7 @@ pub fn hget(hash: &str, key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(del("key"), "del key\r\n");
 pub fn del(key: &str) -> String {
@@ -83,7 +83,7 @@ pub fn del(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(expire("key", 1000), "expire key 1000\r\n");
 pub fn expire(key: &str, seconds: usize) -> String {
@@ -94,7 +94,7 @@ pub fn expire(key: &str, seconds: usize) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(incr("key"), "incr key\r\n");
 pub fn incr(key: &str) -> String {
@@ -105,7 +105,7 @@ pub fn incr(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(decr("key"), "decr key\r\n");
 pub fn decr(key: &str) -> String {
@@ -116,7 +116,7 @@ pub fn decr(key: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(append("key", "value"), "append key value\r\n");
 pub fn append(key: &str, value: &str) -> String {
@@ -127,7 +127,7 @@ pub fn append(key: &str, value: &str) -> String {
 ///
 /// # Example
 /// ```
-/// # use request::redis::*;
+/// # use rpcperf_request::redis::*;
 ///
 /// assert_eq!(prepend("key", "value"), "prepend key value\r\n");
 pub fn prepend(key: &str, value: &str) -> String {

--- a/lib/request/src/thrift.rs
+++ b/lib/request/src/thrift.rs
@@ -39,7 +39,7 @@ impl Buffer {
     ///
     /// # Example
     /// ```
-    /// # use request::thrift::*;
+    /// # use rpcperf_request::thrift::*;
     ///
     // let mut buffer = Vec::<u8>::new();
     // protocol_header(&mut buffer);
@@ -54,7 +54,7 @@ impl Buffer {
     ///
     /// # Example
     /// ```
-    /// # use request::thrift::*;
+    /// # use rpcperf_request::thrift::*;
     ///
     /// let mut b = Buffer::new();
     /// b.sequence_id(0_i32);
@@ -71,7 +71,7 @@ impl Buffer {
     ///
     /// # Example
     /// ```
-    /// # use request::thrift::Buffer;
+    /// # use rpcperf_request::thrift::Buffer;
     ///
     /// let mut b = Buffer::new();
     /// b.method_name("ping".to_string());
@@ -85,7 +85,7 @@ impl Buffer {
     ///
     /// # Example
     /// ```
-    /// # use request::thrift::Buffer;
+    /// # use rpcperf_request::thrift::Buffer;
     ///
     /// let mut b = Buffer::new();
     /// b.sequence_id(0_i32);
@@ -99,7 +99,7 @@ impl Buffer {
     ///
     /// # Example
     /// ```
-    /// # use request::thrift::Buffer;
+    /// # use rpcperf_request::thrift::Buffer;
     ///
     /// let mut b = Buffer::new();
     /// b.stop();
@@ -134,7 +134,7 @@ impl Buffer {
 ///
 /// # Example
 /// ```
-/// # use request::thrift::*;
+/// # use rpcperf_request::thrift::*;
 ///
 /// assert_eq!(ping(), [0, 0, 0, 17, 128, 1, 0, 1, 0, 0, 0, 4, 112, 105, 110, 103, 0, 0, 0, 0, 0]);
 pub fn ping() -> Vec<u8> {

--- a/lib/workload/Cargo.toml
+++ b/lib/workload/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
-name = "workload"
-version = "0.2.1"
+name = "rpcperf_workload"
+version = "1.0.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-license = "apache-2.0"
+license = "Apache-2.0"
 
 description = "rpc-perf workload generation"
 
+homepage = "https://github.com/twitter/rpc-perf"
+repository = "https://github.com/twitter/rpc-perf"
+
+readme = "README.md"
+
 [dependencies]
 log = "0.3.5"
-time = "0.1.34"
+mpmc = "0.1.2"
+pad = "0.1.4"
 rand = "0.3.14"
 ratelimit = "0.2.4"
+rpcperf_request = "1.0.0"
 shuteye = "0.1.1"
-pad = "0.1.4"
-
-[dependencies.mpmc]
-git = "https://github.com/brayniac/mpmc"
-
-[dependencies.request]
-path = "../request/"
+time = "0.1.34"

--- a/lib/workload/README.md
+++ b/lib/workload/README.md
@@ -1,0 +1,3 @@
+# rpcperf_workload - workload generation for rpc-perf
+
+This crate is intended for use by rpc-perf for generating test workloads.

--- a/lib/workload/src/lib.rs
+++ b/lib/workload/src/lib.rs
@@ -14,15 +14,15 @@
 //  limitations under the License.
 
 #![crate_type = "lib"]
-#![crate_name = "workload"]
+#![crate_name = "rpcperf_workload"]
 
 extern crate mpmc;
 extern crate pad;
-extern crate request;
-extern crate ratelimit;
-extern crate time;
 extern crate rand;
+extern crate ratelimit;
+extern crate rpcperf_request as request;
 extern crate shuteye;
+extern crate time;
 
 const ONE_SECOND: u64 = 1_000_000_000;
 pub const BUCKET_SIZE: usize = 10_000;

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@
 
 extern crate log;
 extern crate toml;
-extern crate workload;
+extern crate rpcperf_workload as workload;
 
 use std::fs::File;
 use std::io::Read;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -15,7 +15,6 @@
 
 extern crate mio;
 extern crate time;
-extern crate parser;
 
 use bytes::{Buf, ByteBuf, MutByteBuf};
 use mio::{TryRead, TryWrite};

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,13 @@ extern crate histogram;
 extern crate time;
 extern crate mio;
 extern crate mpmc;
-extern crate parser;
 extern crate regex;
-extern crate request;
+extern crate rpcperf_parser as parser;
+extern crate rpcperf_request as request;
+extern crate rpcperf_workload as workload;
 extern crate shuteye;
 extern crate toml;
 extern crate waterfall;
-extern crate workload;
 
 pub mod client;
 pub mod config;

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -18,9 +18,9 @@ use std::process::Command;
 #[cfg(test)]
 #[test]
 fn main() {
-    test_subcrate("parser");
-    test_subcrate("request");
-    test_subcrate("workload");
+    test_subcrate("rpcperf_parser");
+    test_subcrate("rpcperf_request");
+    test_subcrate("rpcperf_workload");
 }
 
 fn test_subcrate(subcrate: &'static str) {


### PR DESCRIPTION
- indicate nightly date for rpc-perf
- fix license strings
- add homepage and repository metadata
- mpmc 0.1.2 from crates.io
- prefix parser, request, workload, with rpcperf_
- bump parser to 1.0.0
- bump request to 1.0.0
- bump workload to 1.0.0