### PR TITLE
generic thrift support

### DIFF
--- a/configs/thrift_calc.toml
+++ b/configs/thrift_calc.toml
@@ -1,0 +1,57 @@
+# this example illustrates using rpc-perf with generic thrift protocols
+# in this particular case, we benchmark the tutorial calculator example
+#
+# use-case: demonstrate thrift functionality
+
+[general]
+protocol = "thrift"
+
+# this is just the ping, it's not currently generic anyway
+[[workload]]
+name = "ping"
+method = "ping"
+rate = 1
+
+# this is a modified addition example, randomly generate the numbers
+[[workload]]
+name = "add"
+method = "add"
+rate = 1
+  [[workload.parameter]]
+  id = 1
+  type = "i32"
+  style = "random"
+  regenerate = true
+  [[workload.parameter]]
+  id = 2
+  type = "i32"
+  style = "random"
+  regenerate = true
+
+# this is an exact copy of the example subtraction: 15 - 10 = 5
+# it also shows how we can do structs
+[[workload]]
+name = "sub"
+method = "calculate"
+rate = 1
+  [[workload.parameter]]
+  id = 1 # this is the operation log id
+  type = "i32"
+  seed = 1
+  [[workload.parameter]]
+  id = 2 # this is the work struct
+  type = "struct"
+  [[workload.parameter]]
+  id = 1 # this is the thing to subtract from
+  type = "i32"
+  seed = 15 # here is the value
+  [[workload.parameter]]
+  id = 2 # here is the thing to subtract
+  type = "i32"
+  seed = 10 # here is the value
+  [[workload.parameter]]
+  id = 3 # this is the op type field
+  type = "i32"
+  seed = 2 # 2 is for subtration
+  [[workload.parameter]]
+  type = "stop" #required to end the struct

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,6 +61,7 @@ impl mio::Handler for Client {
             State::Writing => {
                 match self.work_rx.pop() {
                     Some(work) => {
+                        trace!("sending: {:?}", work);
                         self.connections[token].ready(event_loop, events, Some(work));
                     }
                     None => {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -22,11 +22,11 @@ pub struct SimpleLogger;
 
 impl log::Log for SimpleLogger {
     fn enabled(&self, metadata: &LogMetadata) -> bool {
-        metadata.level() <= LogLevel::Debug
+        metadata.level() <= LogLevel::Trace
     }
 
     fn log(&self, record: &LogRecord) {
-        if self.enabled(record.metadata()) && record.location().module_path() == "rpc_perf" {
+        if self.enabled(record.metadata()) {
             println!("{} {:<5} [{}] {}",
                      time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
                      record.level().to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,13 +357,15 @@ pub fn main() {
     info!("-----");
     info!("Workload:");
 
-    for (i,w) in config.workloads.iter().enumerate() {
-        //let w = &config.workloads[i];
+    for (i, w) in config.workloads.iter().enumerate() {
         info!("Workload {}: Method: {} Rate: {}", i, w.method, w.rate);
 
         let protocol = Protocol::new(&config.protocol.clone()).unwrap();
 
-        let mut workload = Workload::new(protocol, w.method.clone(), Some(w.rate as u64), workq.clone())
+        let mut workload = Workload::new(protocol,
+                                         w.method.clone(),
+                                         Some(w.rate as u64),
+                                         workq.clone())
                                .unwrap();
 
         for p in &w.parameters {


### PR DESCRIPTION
- add generic thrift support to rpc-perf
- rpcperf: config file changes to support
- rpcperf_request: support generic thrift requests
- rpcperf_workload: major changes
- travis: mark osx can fail, enable fast finsh