### PR TITLE
workload: unnecessary clone()

### DIFF
--- a/lib/workload/src/lib.rs
+++ b/lib/workload/src/lib.rs
@@ -412,7 +412,7 @@ impl Workload {
                     panic!("unsupported protocol");
                 }
             };
-            let _ = self.queue.push(query.clone());
+            let _ = self.queue.push(query);
         }
     }
 }


### PR DESCRIPTION
- this change removes an unnecessary clone when pushing to the work queue