### PR TITLE
request timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-nightly.20160422"
+version = "1.0.0-beta.1"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9,14 +9,15 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "rpcperf_request 1.1.0",
+ "rpcperf_request 1.2.0",
  "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -34,7 +35,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "odds 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -54,7 +55,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -180,7 +181,7 @@ name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -191,21 +192,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lodepng"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c_vec 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -239,7 +235,7 @@ dependencies = [
  "nix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -249,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -266,7 +262,7 @@ dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -284,7 +280,7 @@ name = "nodrop"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "odds 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -321,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "odds"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -351,19 +347,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.69"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -372,7 +368,7 @@ version = "0.1.0"
 dependencies = [
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -382,7 +378,7 @@ dependencies = [
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -392,7 +388,7 @@ dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -401,7 +397,7 @@ version = "0.1.0"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -411,12 +407,12 @@ dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rpcperf_request"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -430,18 +426,18 @@ dependencies = [
  "rpcperf_thrift 0.1.0",
  "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rpcperf_thrift"
 version = "0.1.0"
 dependencies = [
- "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -496,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -509,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -527,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,13 +565,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heatmap 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lodepng 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lodepng 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -588,7 +584,7 @@ name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "1.0.0-nightly.20160422"
+version = "1.0.0-beta.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -46,6 +46,7 @@ histogram = "0.3.6"
 log = "0.3.5"
 mio = "0.5.0"
 mpmc = "0.1.2"
+pad = "0.1.4"
 regex = "0.1.41"
 rpcperf_request = { path = "./lib/request", version = "1.1.0" }
 rpcperf_cfgtypes = { path = "./lib/cfgtypes", version = "0.1.0" }

--- a/lib/request/Cargo.toml
+++ b/lib/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_request"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"

--- a/lib/request/src/config.rs
+++ b/lib/request/src/config.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-
 use getopts::Matches;
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -32,7 +30,6 @@ use ping;
 use thrift;
 use cfgtypes::{ProtocolParse, ProtocolParseFactory};
 use super::BenchmarkConfig;
-
 
 /// Helper for extracting non-string values from the `Matches`
 fn parse_opt<F>(name: &str, matches: &Matches) -> Result<Option<F>, String>
@@ -124,7 +121,7 @@ fn load_config_table(table: BTreeMap<String, Value>,
         if let Some(connections) = general.get("connections")
                                           .and_then(|k| k.as_integer()) {
             config.connections = connections as usize;
-        };
+        }
         if let Some(threads) = general.get("threads").and_then(|k| k.as_integer()) {
             config.threads = threads as usize;
         }
@@ -145,6 +142,12 @@ fn load_config_table(table: BTreeMap<String, Value>,
         if let Some(ipv6) = general.get("ipv6").and_then(|k| k.as_bool()) {
             config.ipv6 = ipv6;
         }
+        if let Some(timeout) = general.get("timeout").and_then(|k| k.as_integer()) {
+            config.timeout = Some(timeout as u64);
+        }
+        if let Some(evtick) = general.get("evtick").and_then(|k| k.as_integer()) {
+            config.evtick = evtick as u64;
+        }
     }
 
     // get any overrides from the command line
@@ -156,7 +159,6 @@ fn load_config_table(table: BTreeMap<String, Value>,
 /// Override parameters using command line arguments
 fn config_overrides(config: &mut BenchmarkConfig, matches: &Matches) -> Result<(), String> {
     // override config with commandline options
-
 
     if let Some(threads) = try!(parse_opt("threads", matches)) {
         config.threads = threads;
@@ -172,6 +174,14 @@ fn config_overrides(config: &mut BenchmarkConfig, matches: &Matches) -> Result<(
 
     if let Some(duration) = try!(parse_opt("duration", matches)) {
         config.duration = duration;
+    }
+
+    if let Some(timeout) = try!(parse_opt("timeout", matches)) {
+        config.timeout = Some(timeout);
+    }
+
+    if let Some(evtick) = try!(parse_opt("evtick", matches)) {
+        config.evtick = evtick;
     }
 
     if matches.opt_present("tcp-nodelay") {

--- a/lib/request/src/lib.rs
+++ b/lib/request/src/lib.rs
@@ -45,6 +45,8 @@ pub struct BenchmarkConfig {
     pub tcp_nodelay: bool,
     pub ipv4: bool,
     pub ipv6: bool,
+    pub timeout: Option<u64>,
+    pub evtick: u64,
     pub protocol_config: ProtocolConfig,
 }
 
@@ -58,6 +60,8 @@ impl BenchmarkConfig {
             tcp_nodelay: false,
             ipv4: true,
             ipv6: true,
+            timeout: None,
+            evtick: 100,
             protocol_config: protocol,
         }
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -13,10 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+extern crate pad;
 extern crate time;
 extern crate log;
 
-use log::{Log, LogLevel, LogMetadata, LogRecord};
+use pad::{PadStr, Alignment};
+use log::{LogLevel, LogMetadata, LogRecord};
 
 pub struct SimpleLogger;
 
@@ -27,8 +29,12 @@ impl log::Log for SimpleLogger {
 
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {
-            println!("{} {:<5} [{}] {}",
+            let ms = format!("{:.*}",
+                             3,
+                             ((time::precise_time_ns() % 1_000_000_000) / 1_000_000));
+            println!("{}.{} {:<5} [{}] {}",
                      time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
+                     ms.pad(3, '0', Alignment::Right, true),
                      record.level().to_string(),
                      "rpc-perf",
                      record.args());

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,7 +14,7 @@
 //  limitations under the License.
 
 // The current state of the client connection
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,PartialEq)]
 pub enum State {
     Reading,
     Writing,


### PR DESCRIPTION
- typical clients offer a timeout setting for requests, as described in #97 we wish to add this feature to rpc-perf
- adding a global request timeout to the config / command line arguments
- implement a timeout handler to drop the connection and re-connect
- change to client/connection to support the new behavior
- logging now includes milliseconds to assist with debugging