### PR TITLE
update ratelimit and shuteye

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-beta.1"
+version = "1.0.0-nightly.20160806"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,8 +12,8 @@ dependencies = [
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
- "rpcperf_request 1.2.0",
- "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_request 1.3.0",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -338,11 +338,10 @@ dependencies = [
 
 [[package]]
 name = "ratelimit"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -412,20 +411,19 @@ dependencies = [
 
 [[package]]
 name = "rpcperf_request"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ratelimit 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpcperf_cfgtypes 0.1.0",
  "rpcperf_echo 0.1.0",
  "rpcperf_memcache 0.1.0",
  "rpcperf_ping 0.1.0",
  "rpcperf_redis 0.1.0",
  "rpcperf_thrift 0.1.0",
- "shuteye 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -456,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "shuteye"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "1.0.0-beta.1"
+version = "1.0.0-nightly.20160806"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -50,7 +50,7 @@ pad = "0.1.4"
 regex = "0.1.41"
 rpcperf_request = { path = "./lib/request", version = "1.1.0" }
 rpcperf_cfgtypes = { path = "./lib/cfgtypes", version = "0.1.0" }
-shuteye = "0.1.1"
+shuteye = "0.2.0"
 simple_logger = "0.4.0"
 tiny_http = "0.5.1"
 time = "0.1.34"

--- a/lib/request/Cargo.toml
+++ b/lib/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_request"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -16,9 +16,8 @@ readme = "README.md"
 getopts = "0.2.14"
 log = "0.3.5"
 mpmc = "0.1.2"
-ratelimit = "0.2.4"
-shuteye = "0.1.1"
-time = "0.1.34"
+ratelimit = "0.3.1"
+shuteye = "0.2.0"
 toml = "0.1.27"
 rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
 rpcperf_echo = { path = "../echo", version = "0.1.0" }

--- a/lib/request/src/config.rs
+++ b/lib/request/src/config.rs
@@ -28,7 +28,6 @@ use memcache;
 use redis;
 use ping;
 use thrift;
-use cfgtypes::{ProtocolParse, ProtocolParseFactory};
 use super::BenchmarkConfig;
 
 /// Helper for extracting non-string values from the `Matches`

--- a/lib/request/src/lib.rs
+++ b/lib/request/src/lib.rs
@@ -23,7 +23,6 @@ extern crate toml;
 extern crate mpmc;
 extern crate ratelimit;
 extern crate shuteye;
-extern crate time;
 
 extern crate rpcperf_cfgtypes as cfgtypes;
 extern crate rpcperf_echo as echo;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -25,14 +25,16 @@ use std::fmt;
 use std::net::ToSocketAddrs;
 use std::process;
 use std::sync::mpsc;
+use std::time::Duration;
 
 use heatmap::Heatmap;
 use histogram::Histogram;
 use tiny_http::{Server, Response, Request};
 use waterfall::Waterfall;
 
-const ONE_MILISECOND: i64 = 1_000_000;
-const ONE_SECOND: u64 = 1_000_000_000;
+const ONE_MICROSECOND: u32 = 1000;
+const ONE_MILISECOND: u32 = 1000 * ONE_MICROSECOND;
+const ONE_SECOND: u64 = 1000 * ONE_MILISECOND as u64;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Counter {
@@ -366,7 +368,7 @@ impl Receiver {
                     }
                 }
                 Err(_) => {
-                    shuteye::sleep(shuteye::Timespec::from_nano(ONE_MILISECOND).unwrap());
+                    shuteye::sleep(Duration::new(0, ONE_MILISECOND));
                 }
             }
 


### PR DESCRIPTION
- update to new versions of ratelimit and shuteye
- removes dependency on time for workload
- no measurable performance change