### PR TITLE
install instructions fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,6 @@ rpc-perf was created to help measure the performance of caching systems. We've f
 
 rpc-perf is built through the `cargo` command which ships with rust. If you don't have rust installed, I recommend using [multirust][1] to manage your rust installation. Otherwise, follow the instructions on [rust-lang.org][2] to get rust and cargo installed. rpc-perf targets stable rust. You can follow either of the two paths below to get a working rpc-perf binary
 
-### Install with cargo
-
-With rust installed, simply run:
-
-```shell
-cargo install rpc-perf
-```
-
-You may then run rpc-perf from your cargo path. You will want to use a config from the configs directory of this repository.
-
 ### Build from source
 
 With rust installed, clone this repo, and cd into this folder:


### PR DESCRIPTION
- the version on crates.io is old, remove cargo install references
- fixes #105