### PR TITLE
Redis database selection

### DIFF
--- a/configs/default.toml
+++ b/configs/default.toml
@@ -12,6 +12,7 @@ protocol = "memcache"
 tcp-nodelay = false
 ipv4 = true
 ipv6 = true
+database = 0
 
 [[workload]]
 name = "get"

--- a/lib/redis/src/gen.rs
+++ b/lib/redis/src/gen.rs
@@ -22,7 +22,7 @@ pub fn flushall() -> String {
 }
 
 /// SELECT request
-pub fn select_(database: &str) -> String {
+pub fn select(database: &str) -> String {
     format!("select {}\r\n", database)
 }
 

--- a/lib/redis/src/gen.rs
+++ b/lib/redis/src/gen.rs
@@ -22,7 +22,7 @@ pub fn flushall() -> String {
 }
 
 /// SELECT request
-pub fn select(database: &str) -> String {
+pub fn select(database: &i64) -> String {
     format!("select {}\r\n", database)
 }
 

--- a/lib/redis/src/gen.rs
+++ b/lib/redis/src/gen.rs
@@ -21,6 +21,11 @@ pub fn flushall() -> String {
     "flushall\r\n".to_owned()
 }
 
+/// SELECT request
+pub fn select_(database: &str) -> String {
+    format!("select {}\r\n", database)
+}
+
 #[test]
 fn test_flushall() {
     assert_eq!(flushall(), "flushall\r\n");

--- a/lib/redis/src/gen.rs
+++ b/lib/redis/src/gen.rs
@@ -22,7 +22,7 @@ pub fn flushall() -> String {
 }
 
 /// SELECT request
-pub fn select(database: &i64) -> String {
+pub fn select(database: &u32) -> String {
     format!("select {}\r\n", database)
 }
 

--- a/lib/redis/src/lib.rs
+++ b/lib/redis/src/lib.rs
@@ -92,7 +92,7 @@ struct RedisParse;
 
 struct RedisParseFactory {
     flush: bool,
-    database: i64,
+    database: u32,
 }
 
 impl ProtocolGen for Command {
@@ -146,7 +146,7 @@ pub fn load_config(table: &BTreeMap<String, Value>, matches: &Matches) -> CResul
                 .and_then(|k| k.as_table())
                 .and_then(|k| k.get("database"))
                 .and_then(|k| k.as_integer())
-        .unwrap_or(0);
+        .unwrap_or(0) as u32;
 
     if let Some(&Value::Array(ref workloads)) = table.get("workload") {
         for workload in workloads.iter() {

--- a/lib/redis/src/lib.rs
+++ b/lib/redis/src/lib.rs
@@ -117,9 +117,9 @@ impl ProtocolParseFactory for RedisParseFactory {
 
     fn prepare(&self) -> CResult<Vec<Vec<u8>>> {
         Ok(if self.flush {
-            vec![gen::flushall().into_bytes(), gen::select_(&self.database).into_bytes()]
+            vec![gen::flushall().into_bytes(), gen::select(&self.database).into_bytes()]
         } else {
-            vec![gen::select_(&self.database).into_bytes()]
+            vec![gen::select(&self.database).into_bytes()]
         }
         )
     }
@@ -152,7 +152,7 @@ pub fn load_config(table: &BTreeMap<String, Value>, matches: &Matches) -> CResul
 
         let proto = Arc::new(RedisParseFactory {
             flush: matches.opt_present("flush"),
-            database: matches.opt_str("database").unwrap_or("0".to_string())
+            database: matches.opt_str("database").unwrap_or("0".to_owned())
         });
 
         Ok(ProtocolConfig {

--- a/lib/redis/src/lib.rs
+++ b/lib/redis/src/lib.rs
@@ -92,7 +92,7 @@ struct RedisParse;
 
 struct RedisParseFactory {
     flush: bool,
-    database: String,
+    database: i64,
 }
 
 impl ProtocolGen for Command {
@@ -141,6 +141,13 @@ pub fn load_config(table: &BTreeMap<String, Value>, matches: &Matches) -> CResul
 
     let mut ws = Vec::new();
 
+    let database =
+            table.get("general")
+                .and_then(|k| k.as_table())
+                .and_then(|k| k.get("database"))
+                .and_then(|k| k.as_integer())
+        .unwrap_or(0);
+
     if let Some(&Value::Array(ref workloads)) = table.get("workload") {
         for workload in workloads.iter() {
             if let Value::Table(ref workload) = *workload {
@@ -152,7 +159,7 @@ pub fn load_config(table: &BTreeMap<String, Value>, matches: &Matches) -> CResul
 
         let proto = Arc::new(RedisParseFactory {
             flush: matches.opt_present("flush"),
-            database: matches.opt_str("database").unwrap_or("0".to_owned())
+            database: database,
         });
 
         Ok(ProtocolConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ pub fn opts() -> Options {
     opts.optopt("w", "windows", "number of windows in test", "INTEGER");
     opts.optopt("", "timeout", "request timeout in milliseconds", "INTEGER");
     opts.optopt("p", "protocol", "client protocol", "STRING");
+    opts.optopt("a", "database", "Redis database", "STRING");
     opts.optopt("", "config", "TOML config file", "FILE");
     opts.optopt("", "listen", "listen address for stats", "HOST:PORT");
     opts.optopt("", "trace", "write histogram data to file", "FILE");

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,6 @@ pub fn opts() -> Options {
     opts.optopt("w", "windows", "number of windows in test", "INTEGER");
     opts.optopt("", "timeout", "request timeout in milliseconds", "INTEGER");
     opts.optopt("p", "protocol", "client protocol", "STRING");
-    opts.optopt("a", "database", "Redis database", "STRING");
     opts.optopt("", "config", "TOML config file", "FILE");
     opts.optopt("", "listen", "listen address for stats", "HOST:PORT");
     opts.optopt("", "trace", "write histogram data to file", "FILE");


### PR DESCRIPTION
This PR adds a `--database` option to rpc-perf, so that when initially connecting to a Redis instance you can select which database to use.

I've been using it to measure the overhead of mixing writes to different keyspaces vs. the same, db0, keyspace.