### PR TITLE
common library for shared dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,45 +1,42 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-nightly.20160914"
+version = "1.0.0-nightly.20170109"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "rpcperf_request 1.3.0",
+ "mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
+ "rpcperf_request 1.3.1",
  "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tic 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.3.16"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ascii"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -54,7 +51,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -74,10 +71,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -91,7 +88,7 @@ name = "clocksource"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -104,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "encoding"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,7 +185,7 @@ name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -204,7 +201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -213,7 +210,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c_vec 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -223,41 +220,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mio"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miow"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -268,24 +265,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nix"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -293,20 +290,20 @@ dependencies = [
 
 [[package]]
 name = "nodrop"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -314,7 +311,7 @@ name = "num-integer"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -323,17 +320,17 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "odds"
-version = "0.2.14"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -341,15 +338,15 @@ name = "pad"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -362,101 +359,106 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.77"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rpcperf_cfgtypes"
+version = "0.1.1"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_common 0.1.0",
+]
+
+[[package]]
+name = "rpcperf_common"
 version = "0.1.0"
 dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rpcperf_echo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
 ]
 
 [[package]]
 name = "rpcperf_memcache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
 ]
 
 [[package]]
 name = "rpcperf_ping"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
 ]
 
 [[package]]
 name = "rpcperf_redis"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
 ]
 
 [[package]]
 name = "rpcperf_request"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "rpcperf_echo 0.1.0",
- "rpcperf_memcache 0.1.0",
- "rpcperf_ping 0.1.0",
- "rpcperf_redis 0.1.0",
- "rpcperf_thrift 0.1.0",
- "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
+ "rpcperf_echo 0.1.1",
+ "rpcperf_memcache 0.2.0",
+ "rpcperf_ping 0.1.1",
+ "rpcperf_redis 0.2.0",
+ "rpcperf_thrift 0.1.1",
 ]
 
 [[package]]
 name = "rpcperf_thrift"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.0",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.1",
+ "rpcperf_common 0.1.0",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -472,7 +474,7 @@ name = "rusttype"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -510,19 +512,20 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -535,9 +538,9 @@ dependencies = [
  "heatmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "histogram 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -547,49 +550,58 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tiny_http"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ascii 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.1.30"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "utf8-ranges"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -597,8 +609,8 @@ name = "uuid"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -619,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -632,25 +644,25 @@ name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-"checksum arrayvec 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "16e3bdb2f54b3ace0285975d59a97cf8ed3855294b2b6bc651fcf22a9c352975"
-"checksum ascii 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df73fa4497e77719e23ee7e36e548486bb6559343f6ea56cc96a835fbece5ca0"
+"checksum aho-corasick 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f660b942762979b56c9f07b4b36bb559776fbad102f05d6771e1b629e8fd5bf"
+"checksum arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d89f1b0e242270b5b797778af0c8d182a1a2ccac5d8d6fadf414223cc0fab096"
+"checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
-"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum c_vec 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9e1d9f7d49e289f36f19effbf3d5a5e30163ecf9c7a3c9be94d5374dec5b9a"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "a714b6792cb4bb07643c35d2a051d92988d4e296322a60825549dd0764bcd396"
+"checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 "checksum clocksource 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52b7f1ed402ddda326c2e16028ca283f3ed931e7cc051d5ab9a635b1d88d320b"
 "checksum crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541a7a4936092a4dac8b3a1dc1abc264372e0ce1e7ab712dfe0484374f5a2b7b"
-"checksum encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1119ca1c88774efeed1a7926958e212e02af7437bdeab8520dbc7aa1abde3026"
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
 "checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
 "checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
 "checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
@@ -664,28 +676,28 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "23e3757828fa702a20072c37ff47938e9dd331b92fac6e223d26d4b7a55f7ee2"
+"checksum libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e030dc72013ed68994d1b2cbf36a94dd0e58418ba949c4b0db7eeb70a7a6352"
 "checksum lodepng 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "20fa9f2831022f250ae83b4b6b5f54667a1e966fa1cfff624c2949d81eefbfdd"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
-"checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum mio 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2dadd39d4b47343e10513ac2a731c979517a4761224ecb6bbd243602300c9537"
-"checksum miow 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5bfc6782530ac8ace97af10a540054a37126b63b0702ddaaa243b73b5745b9a"
+"checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b493dc9fd96bd2077f2117f178172b0765db4dfda3ea4d8000401e6d65d3e80"
+"checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e93e6c806a89abce6b59d120fd62cc9e424afc532453c5ce97328127171dda69"
-"checksum net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6a816012ca11cb47009693c1e0c6130e26d39e4d97ee2a13c50e868ec83e3204"
-"checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
-"checksum nodrop 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4d9a22dbcebdeef7bf275cbf444d6521d4e7a2fee187b72d80dba0817120dd8f"
-"checksum num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "c04bd954dbf96f76bab6e5bd6cef6f1ce1262d15268ce4f926d2b5b778fa7af2"
+"checksum net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "5edf9cb6be97212423aed9413dd4729d62b370b5e1c571750e882cebbbc1e3e2"
+"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
+"checksum nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbadd3f4c98dea0bd3d9b4be4c0cdaf1ab57035cb2e41fce3983db5add7cc5"
+"checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
-"checksum num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
-"checksum odds 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "be1fa2672604634a1f9f89f96db7ae1bd5a10cc8590ee94ffa7d31134968ea48"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
 "checksum pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d1bf3336e626b898e7263790d432a711d4277e22faea20dd9f70e0cab268fa58"
-"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59051db7d98ac50dbd1f174badf73916e74ea8085c0328236dac17b5ad3d3a31"
-"checksum regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)" = "64b03446c466d35b42f2a8b203c8e03ed8b91c0f17b56e1f84f7210a257aa665"
-"checksum regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279401017ae31cf4e15344aa3f085d0e2e5c1e70067289ef906906fdbe92c8fd"
-"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07b8848db3b5b5ba97020c6a756c0fdf2dbf2ad7c0d06aa4344a3f2f49c3fe17"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
@@ -693,18 +705,19 @@ dependencies = [
 "checksum simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a3b341928cec79e536fe62b75bfe2e35891a5e65801ebfbd2741dddf7d7fac"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf3270840fc9de208d63e836eb3fdebb85379e7532f42f1b2cbd505fb6fda08"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55dd963dbaeadc08aa7266bf7f91c3154a7805e32bb94b820b769d2ef3b4744d"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
 "checksum tic 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "483c265561b82917552c32821a74f28a7a70e442bbcd1d282d3b83b16624f666"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
-"checksum tiny_http 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd84e5f7192eb957cc22f1d7b615666013e3b1d0baa810a7cb5661c2ce991d5"
-"checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
-"checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+"checksum tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "40cb03eda293527d079f389c22ce4877051981099347c083ac4732e7e3adf8c6"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)" = "cbaa8377a162d88e7d15db0cf110c8523453edcbc5bc66d2b6fffccffa34a068"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum waterfall 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88cddf7c6380e13e56f3d3d68f5d3d8e64e214fb1e922d6cb0e110d71a8e559e"
-"checksum winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3969e500d618a5e974917ddefd0ba152e4bcaae5eb5d9b8c1fbc008e9e28c24e"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "1.0.0-nightly.20161104"
+version = "1.0.0-nightly.20170109"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -39,28 +39,28 @@ debug-assertions = false
 codegen-units = 1
 
 [dependencies]
-bytes = "0.3.0"
-getopts = "0.2.14"
-log = "0.3.5"
-mio = "0.6.0"
-mpmc = "0.1.2"
-pad = "0.1.4"
-regex = "0.1.41"
-slab = "0.3.0"
-shuteye = "0.2.0"
-simple_logger = "0.4.0"
-tiny_http = "0.5.2"
-tic = "0.1.0"
-time = "0.1.35"
-toml = "0.1.27"
+bytes = "=0.3.0"
+log = "=0.3.6"
+mio = "=0.6.2"
+regex = "=0.2.1"
+slab = "=0.3.0"
+shuteye = "=0.2.0"
+simple_logger = "=0.4.0"
+tiny_http = "=0.5.7"
+tic = "=0.1.0"
+time = "=0.1.35"
 
 [dependencies.rpcperf_request]
 path = "./lib/request"
-version = "1.1.0"
+version = "=1.3.1"
 
 [dependencies.rpcperf_cfgtypes]
 path = "./lib/cfgtypes"
-version = "0.1.0"
+version = "=0.1.1"
+
+[dependencies.rpcperf_common]
+path = "./lib/common"
+version = "=0.1.0"
 
 [features]
 asm = [ "tic/asm" ]

--- a/lib/cfgtypes/Cargo.toml
+++ b/lib/cfgtypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_cfgtypes"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,9 +13,8 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-pad = "0.1.4"
-rand = "0.3.14"
-toml = "0.1.27"
+log = "=0.3.6"
+rpcperf_common = { path = "../common", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/cfgtypes/src/lib.rs
+++ b/lib/cfgtypes/src/lib.rs
@@ -13,13 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-extern crate pad;
-extern crate rand;
-extern crate toml;
+extern crate rpcperf_common as common;
+
+pub use common::config::{Value, Parser};
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use toml::Value;
 
 pub mod tools;
 

--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rpcperf_common"
+version = "0.1.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+[dependencies]
+byteorder = "=1.0.0"
+crc = "=1.2.0"
+getopts = "=0.2.14"
+log = "=0.3.6"
+mpmc = "=0.1.2"
+pad = "=0.1.4"
+rand = "=0.3.15"
+ratelimit = "=0.3.1"
+shuteye = "=0.2.0"
+toml = "=0.2.1"

--- a/lib/common/src/lib.rs
+++ b/lib/common/src/lib.rs
@@ -1,5 +1,5 @@
 //  rpc-perf - RPC Performance Testing
-//  Copyright 2015 Twitter, Inc
+//  Copyright 2017 Twitter, Inc
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -13,19 +13,35 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use common::padding::{PadStr, Alignment};
-use common::random::{thread_rng, Rng};
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mpmc;
+extern crate pad;
+extern crate ratelimit;
+extern crate toml;
+extern crate rand;
 
-
-pub fn random_string(size: usize) -> String {
-    thread_rng().gen_ascii_chars().take(size).collect()
+pub mod random {
+    pub use rand::*;
+}
+pub mod checksum {
+    pub use crc::*;
+}
+pub mod padding {
+    pub use pad::*;
+}
+pub mod bytes {
+    pub use byteorder::*;
+}
+pub mod options {
+    pub use getopts::*;
+}
+pub mod limits {
+    pub use ratelimit::*;
+}
+pub mod config {
+    pub use toml::*;
 }
 
-pub fn random_bytes(size: usize) -> Vec<u8> {
-    random_string(size).into_bytes()
-}
-
-pub fn seeded_string(size: usize, seed: usize) -> String {
-    let s = format!("{}", seed);
-    s.pad(size, '0', Alignment::Right, true)
-}
+pub use mpmc::Queue as Queue;

--- a/lib/echo/Cargo.toml
+++ b/lib/echo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_echo"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,10 +13,9 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-crc = "1.2.0"
-log = "0.3.5"
-toml = "0.1.27"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
+log = "=0.3.6"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/echo/src/gen.rs
+++ b/lib/echo/src/gen.rs
@@ -16,12 +16,12 @@
 #[cfg(feature = "unstable")]
 extern crate test;
 
-use crc::crc32;
+use common::checksum;
 use std::mem::transmute;
 
 /// create an echo request with given value
 pub fn echo(value: &[u8]) -> Vec<u8> {
-    let crc = crc32::checksum_ieee(value);
+    let crc = checksum::crc32::checksum_ieee(value);
     let mut msg: Vec<u8> = Vec::new();
     msg.extend(value.iter().cloned());
     let bytes: [u8; 4] = unsafe { transmute(crc.to_be()) };

--- a/lib/echo/src/lib.rs
+++ b/lib/echo/src/lib.rs
@@ -17,9 +17,8 @@
 
 #[macro_use]
 extern crate log;
-extern crate crc;
 extern crate rpcperf_cfgtypes as cfgtypes;
-extern crate toml;
+extern crate rpcperf_common as common;
 
 mod gen;
 mod parse;
@@ -27,7 +26,6 @@ mod parse;
 use cfgtypes::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use toml::Value;
 
 struct EchoParser;
 

--- a/lib/echo/src/parse.rs
+++ b/lib/echo/src/parse.rs
@@ -13,14 +13,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-extern crate crc;
-
-pub use cfgtypes::ParsedResponse;
-
-pub use crc::crc32;
+use cfgtypes::ParsedResponse;
+pub use common::checksum::crc32;
 
 use std::mem::transmute;
-
 
 pub fn parse_response(response: &[u8]) -> ParsedResponse {
 
@@ -40,7 +36,7 @@ pub fn parse_response(response: &[u8]) -> ParsedResponse {
         return ParsedResponse::Unknown;
     }
 
-    let crc_calc = crc::crc32::checksum_ieee(value);
+    let crc_calc = crc32::checksum_ieee(value);
     let crc_bytes: [u8; 4] = unsafe { transmute(crc_calc.to_be()) };
     if crc == crc_bytes {
         return ParsedResponse::Ok;

--- a/lib/memcache/Cargo.toml
+++ b/lib/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_memcache"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,10 +13,9 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-getopts = "0.2.14"
-log = "0.3.5"
-toml = "0.1.27"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
+log = "=0.3.6"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/memcache/src/parse.rs
+++ b/lib/memcache/src/parse.rs
@@ -15,7 +15,6 @@
 
 pub use cfgtypes::ParsedResponse;
 
-
 pub fn parse_response(response: &str) -> ParsedResponse {
 
     let mut lines: Vec<&str> = response.split("\r\n").collect();

--- a/lib/ping/Cargo.toml
+++ b/lib/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_ping"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,9 +13,9 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-log = "0.3.5"
-toml = "0.1.27"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
+log = "=0.3.6"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0"}
 
 [profile.dev]
 opt-level = 0

--- a/lib/ping/src/lib.rs
+++ b/lib/ping/src/lib.rs
@@ -16,20 +16,17 @@
 #![cfg_attr(feature = "unstable", feature(test))]
 
 extern crate rpcperf_cfgtypes as cfgtypes;
-extern crate toml;
 
 mod gen;
 mod parse;
 
 use cfgtypes::{BenchmarkWorkload, CResult, ParsedResponse, ProtocolConfig, ProtocolGen,
-               ProtocolParse, ProtocolParseFactory};
+               ProtocolParse, ProtocolParseFactory, Value};
 use std::collections::BTreeMap;
 use std::str;
 use std::sync::Arc;
-use toml::Value;
 
 struct Ping;
-
 
 impl ProtocolGen for Ping {
     fn generate_message(&mut self) -> Vec<u8> {

--- a/lib/redis/Cargo.toml
+++ b/lib/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_redis"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,10 +13,9 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-getopts = "0.2.14"
-log = "0.3.5"
-toml = "0.1.27"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
+log = "=0.3.6"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/request/Cargo.toml
+++ b/lib/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_request"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -13,18 +13,14 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-getopts = "0.2.14"
-log = "0.3.5"
-mpmc = "0.1.2"
-ratelimit = "0.3.1"
-shuteye = "0.2.0"
-toml = "0.1.27"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
-rpcperf_echo = { path = "../echo", version = "0.1.0" }
-rpcperf_memcache = { path = "../memcache", version = "0.1.0" }
-rpcperf_redis = { path = "../redis", version = "0.1.0" }
-rpcperf_ping = { path = "../ping", version = "0.1.0" }
-rpcperf_thrift = { path = "../thrift", version = "0.1.0" }
+log = "=0.3.6"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_echo = { path = "../echo", version = "0.1.1" }
+rpcperf_memcache = { path = "../memcache", version = "0.2.0" }
+rpcperf_redis = { path = "../redis", version = "0.2.0" }
+rpcperf_ping = { path = "../ping", version = "0.1.1" }
+rpcperf_thrift = { path = "../thrift", version = "0.1.1" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/request/src/config.rs
+++ b/lib/request/src/config.rs
@@ -13,15 +13,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use getopts::Matches;
+use common::options::Matches;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
-use toml::Parser;
-use toml::Value;
-use toml::Value::Table;
+use cfgtypes::Parser;
+use cfgtypes::Value;
+use cfgtypes::Value::Table;
 
 use echo;
 use memcache;

--- a/lib/request/src/lib.rs
+++ b/lib/request/src/lib.rs
@@ -17,14 +17,9 @@
 
 #[macro_use]
 extern crate log;
-extern crate getopts;
-extern crate toml;
-
-extern crate mpmc;
-extern crate ratelimit;
-extern crate shuteye;
 
 extern crate rpcperf_cfgtypes as cfgtypes;
+extern crate rpcperf_common as common;
 extern crate rpcperf_echo as echo;
 extern crate rpcperf_redis as redis;
 extern crate rpcperf_memcache as memcache;

--- a/lib/request/src/workload.rs
+++ b/lib/request/src/workload.rs
@@ -16,15 +16,15 @@
 pub const BUCKET_SIZE: usize = 10_000;
 
 use cfgtypes;
-use mpmc;
-use ratelimit::Ratelimit;
+use common::Queue;
+use common::limits::Ratelimit;
 use std::thread;
 
 use cfgtypes::ProtocolGen;
 
 /// Launch each of the workloads in their own thread
 pub fn launch_workloads(workloads: Vec<cfgtypes::BenchmarkWorkload>,
-                        work_queue: mpmc::Queue<Vec<u8>>) {
+                        work_queue: Queue<Vec<u8>>) {
 
     for (i, w) in workloads.into_iter().enumerate() {
         info!("Workload {}: Method: {} Rate: {}",
@@ -45,13 +45,13 @@ pub fn launch_workloads(workloads: Vec<cfgtypes::BenchmarkWorkload>,
 struct Workload {
     protocol: Box<ProtocolGen>,
     ratelimit: Option<Ratelimit>,
-    queue: mpmc::Queue<Vec<u8>>,
+    queue: Queue<Vec<u8>>,
 }
 
 impl Workload {
     fn new(protocol: Box<ProtocolGen>,
            rate: Option<u64>,
-           queue: mpmc::Queue<Vec<u8>>)
+           queue: Queue<Vec<u8>>)
            -> Result<Workload, &'static str> {
         let mut ratelimit = None;
         if let Some(r) = rate {

--- a/lib/thrift/Cargo.toml
+++ b/lib/thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_thrift"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>",
            "Bryce Anderson <bryce.anderson22@gmail.com"]
 
@@ -14,11 +14,8 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-log = "0.3.5"
-byteorder = "0.5.1"
-rand = "0.3.14"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.0" }
-toml = "*"
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
+rpcperf_common = { path = "../common", version = "0.1.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/thrift/src/buffer.rs
+++ b/lib/thrift/src/buffer.rs
@@ -14,7 +14,7 @@
 //  limitations under the License.
 
 
-use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
+use common::bytes::{ByteOrder, BigEndian, WriteBytesExt};
 
 use consts;
 

--- a/lib/thrift/src/config.rs
+++ b/lib/thrift/src/config.rs
@@ -22,7 +22,7 @@ use super::{Parameter, Tvalue};
 
 use gen;
 use parse;
-use toml::Value;
+use cfgtypes::Value;
 
 struct ThriftParse;
 struct ThriftParseFactory;
@@ -198,7 +198,7 @@ fn extract_parameter(i: usize, parameter: &BTreeMap<String, Value>) -> CResult<P
 
 #[test]
 fn test_load_config() {
-    use toml::Parser;
+    use cfgtypes::Parser;
 
     let table = {
         let config_str = include_str!("../../../configs/thrift_calc.toml");

--- a/lib/thrift/src/gen.rs
+++ b/lib/thrift/src/gen.rs
@@ -142,7 +142,9 @@ mod tests {
     extern crate test;
 
     use super::*;
+    #[allow(unused_imports)]
     use super::super::*;
+    #[allow(unused_imports)]
     use tests;
 
     #[test]

--- a/lib/thrift/src/lib.rs
+++ b/lib/thrift/src/lib.rs
@@ -15,10 +15,8 @@
 
 #![cfg_attr(feature = "unstable", feature(test))]
 
-extern crate byteorder;
-extern crate rand;
 extern crate rpcperf_cfgtypes as cfgtypes;
-extern crate toml;
+extern crate rpcperf_common as common;
 
 #[cfg(test)]
 mod tests;
@@ -29,6 +27,7 @@ mod gen;
 mod parse;
 
 use cfgtypes::{Style, tools};
+use common::random::random;
 
 pub use config::load_config;
 
@@ -70,12 +69,12 @@ pub enum Tvalue {
 impl Tvalue {
     fn regen(&mut self, size: usize) {
         match *self {
-            Tvalue::Bool(ref mut v) => *v = rand::random::<bool>(),
-            Tvalue::Byte(ref mut v) => *v = rand::random::<u8>(),
-            Tvalue::Double(ref mut v) => *v = rand::random::<f64>(),
-            Tvalue::Int16(ref mut v) => *v = rand::random::<i16>(),
-            Tvalue::Int32(ref mut v) => *v = rand::random::<i32>(),
-            Tvalue::Int64(ref mut v) => *v = rand::random::<i64>(),
+            Tvalue::Bool(ref mut v) => *v = random::<bool>(),
+            Tvalue::Byte(ref mut v) => *v = random::<u8>(),
+            Tvalue::Double(ref mut v) => *v = random::<f64>(),
+            Tvalue::Int16(ref mut v) => *v = random::<i16>(),
+            Tvalue::Int32(ref mut v) => *v = random::<i32>(),
+            Tvalue::Int64(ref mut v) => *v = random::<i64>(),
             Tvalue::String(ref mut v) => *v = tools::random_string(size),
             _ => {}
         }

--- a/lib/thrift/src/parse.rs
+++ b/lib/thrift/src/parse.rs
@@ -15,7 +15,7 @@
 
 use cfgtypes::ParsedResponse;
 
-use byteorder::{ByteOrder, BigEndian};
+use common::bytes::{ByteOrder, BigEndian};
 
 pub fn parse_response(response: &[u8]) -> ParsedResponse {
     let bytes = response.len();

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,6 @@
 //  limitations under the License.
 
 extern crate mio;
-extern crate mpmc;
 extern crate slab;
 extern crate tic;
 
@@ -25,7 +24,7 @@ use std::time::Duration;
 
 use mio::deprecated::{EventLoop, EventLoopBuilder, Handler};
 use mio::tcp::TcpStream;
-use mpmc::Queue as BoundedQueue;
+use common::Queue as BoundedQueue;
 use tic::{Clocksource, Sample};
 
 use cfgtypes;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -13,11 +13,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-extern crate pad;
 extern crate time;
 extern crate log;
 
-use pad::{PadStr, Alignment};
+use common::padding::{PadStr, Alignment};
 use log::{LogLevel, LogMetadata, LogRecord};
 
 pub struct SimpleLogger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,18 +17,15 @@
 extern crate log;
 
 extern crate bytes;
-extern crate getopts;
 extern crate tiny_http;
 extern crate time;
 extern crate mio;
-extern crate mpmc;
-extern crate pad;
 extern crate regex;
 extern crate rpcperf_request as request;
 extern crate rpcperf_cfgtypes as cfgtypes;
+extern crate rpcperf_common as common;
 extern crate slab;
 extern crate shuteye;
-extern crate toml;
 extern crate tic;
 
 mod client;
@@ -38,10 +35,10 @@ mod net;
 mod state;
 mod stats;
 
-use getopts::Options;
+use common::options::Options;
+use common::Queue as BoundedQueue;
 use log::LogLevelFilter;
 use mio::deprecated::EventLoopBuilder;
-use mpmc::Queue as BoundedQueue;
 use request::config;
 use std::env;
 use std::thread;


### PR DESCRIPTION
- factor out shared dependencies into new subcrate called common, this gives single touch-point for version changes and reduces likelyhood of version mismatch following cargo update
- refactor callers to use the common library
- update dependencies and use pinned versions
- extend memcache and redis command sets to cure dead code warnings