### PR TITLE
build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rust:
   - nightly
 os:
   - linux
-  - osx
 script:
 - cargo build --verbose
 - cargo build --release --verbose
@@ -16,12 +15,6 @@ matrix:
     - os: linux
       rust: nightly
       script: cargo bench --features unstable
-    - os: osx
-      rust: nightly
-      script: cargo bench --features unstable
     - os: linux
-      rust: nightly
-      script: cargo build --features asm
-    - os: osx
       rust: nightly
       script: cargo build --features asm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-nightly.20170126"
+version = "1.0.0-nightly.20170203"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ codegen-units = 1
 
 [profile.release]
 opt-level = 3
-debug = false
+debug = true
 rpath = false
 lto = true
 debug-assertions = false


### PR DESCRIPTION
- drop osx travis targets to improve CI times. enqueued time is approx 2 hours for osx builds, this drops total CI time to ~10 minutes.
- re-enable debug symbols in release build, this allows profiling. might not work on osx