### PR TITLE
bugfix

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -399,8 +399,10 @@ impl Client {
             } else {
                 match token {
                     TOKEN_TIMER => {
-                        trace!("timeout fired for {:?}", token);
-                        self.timeout(token);
+                        if let Some(token) = self.timer.poll() {
+                            trace!("timeout fired for {:?}", token);
+                            self.timeout(token);
+                        }
                     }
                     TOKEN_QUEUE => {
                         if !self.ready.is_empty() {


### PR DESCRIPTION
- bugfix: timeout handler was passed the token of the timer itself, not the token for the timeout.