### PR TITLE
change request dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,29 +1,16 @@
 [root]
 name = "rpc-perf"
-version = "1.0.0-nightly.20170203"
+version = "2.0.0-pre"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
- "rpcperf_request 1.3.1",
- "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
+ "rpcperf_request 1.4.0",
  "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tic 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -38,11 +25,6 @@ dependencies = [
 [[package]]
 name = "ascii"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -76,7 +58,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,11 +146,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "heatmap"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -233,32 +215,23 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "memchr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mio"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miow"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -282,19 +255,6 @@ dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -367,116 +327,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.4.0"
+name = "redox_syscall"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rpcperf_cfgtypes"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_common 0.1.0",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rpcperf_common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tic 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rpcperf_echo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rpcperf_memcache"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rpcperf_ping"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rpcperf_redis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rpcperf_request"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
- "rpcperf_echo 0.1.1",
- "rpcperf_memcache 0.2.0",
- "rpcperf_ping 0.1.1",
- "rpcperf_redis 0.2.0",
- "rpcperf_thrift 0.1.1",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
+ "rpcperf_echo 0.1.2",
+ "rpcperf_memcache 0.2.1",
+ "rpcperf_ping 0.1.2",
+ "rpcperf_redis 0.2.1",
+ "rpcperf_thrift 0.1.2",
 ]
 
 [[package]]
 name = "rpcperf_thrift"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
- "rpcperf_cfgtypes 0.1.1",
- "rpcperf_common 0.1.0",
+ "rpcperf_cfgtypes 0.1.2",
+ "rpcperf_common 0.2.0",
 ]
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "rusttype"
@@ -486,11 +428,6 @@ dependencies = [
  "arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "shuteye"
@@ -503,7 +440,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,52 +457,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tic"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clocksource 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "heatmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heatmap 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tiny_http"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,14 +512,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "url"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,11 +520,6 @@ dependencies = [
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
@@ -623,16 +531,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "waterfall"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "heatmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heatmap 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lodepng 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,10 +561,8 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f660b942762979b56c9f07b4b36bb559776fbad102f05d6771e1b629e8fd5bf"
 "checksum arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d89f1b0e242270b5b797778af0c8d182a1a2ccac5d8d6fadf414223cc0fab096"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
-"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
@@ -679,7 +580,7 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
-"checksum heatmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30ddbd78282c1517b5f6d87ffb18d865aeb79d4a41a8844acc1150c8a7da4a92"
+"checksum heatmap 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69177865d1d12daa4125452798a9025347c87d2a42def6505fb7692c714326ee"
 "checksum histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b336517dec01c1424711830db4f752ace81ee0459ef37caf9b821932b2f2e59"
 "checksum hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "575fb7f1167f3b88ed825e90eb14918ac460461fdeaa3965c6a50951dee1c970"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -690,12 +591,10 @@ dependencies = [
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26bbb657dd8a31b920792fba3fc60f2c18e9477931c0e01afed98116aa0056a7"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum mio 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b493dc9fd96bd2077f2117f178172b0765db4dfda3ea4d8000401e6d65d3e80"
-"checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
+"checksum mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eecdbdd49a849336e77b453f021c89972a2cfb5b51931a0026ae0ac4602de681"
+"checksum miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a78d2605eb97302c10cf944b8d96b0a2a890c52957caf92fcd1f24f69049579"
 "checksum mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e93e6c806a89abce6b59d120fd62cc9e424afc532453c5ce97328127171dda69"
 "checksum net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "5edf9cb6be97212423aed9413dd4729d62b370b5e1c571750e882cebbbc1e3e2"
-"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
 "checksum nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbadd3f4c98dea0bd3d9b4be4c0cdaf1ab57035cb2e41fce3983db5add7cc5"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
@@ -705,28 +604,20 @@ dependencies = [
 "checksum pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d1bf3336e626b898e7263790d432a711d4277e22faea20dd9f70e0cab268fa58"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59051db7d98ac50dbd1f174badf73916e74ea8085c0328236dac17b5ad3d3a31"
-"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
-"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
-"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07b8848db3b5b5ba97020c6a756c0fdf2dbf2ad7c0d06aa4344a3f2f49c3fe17"
-"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fae018891baadd06ff0281ff137ccd1641044d9bb9498b1138ffecf28f30172"
 "checksum simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a3b341928cec79e536fe62b75bfe2e35891a5e65801ebfbd2741dddf7d7fac"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf3270840fc9de208d63e836eb3fdebb85379e7532f42f1b2cbd505fb6fda08"
-"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
-"checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
-"checksum tic 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6946b8ad47a48a35a5a93f548b6f6208326c2653634b551bd661930aa1d17f6f"
-"checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
-"checksum tiny_http 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "40cb03eda293527d079f389c22ce4877051981099347c083ac4732e7e3adf8c6"
+"checksum tic 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f5cb46916ca3c010ace221a3110d1ef6661e3264fcac360496c539e73a8d772"
+"checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
+"checksum tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "016f040cfc9b5be610de3619eaaa57017fa0b0b678187327bde75fc146e2a41f"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)" = "cbaa8377a162d88e7d15db0cf110c8523453edcbc5bc66d2b6fffccffa34a068"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum waterfall 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2675b148923ed8dd4b723a1b9f782d22d0185b86e2932c80989632b8cb42ac13"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "1.0.0-nightly.20170207"
+version = "2.0.0-pre"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -42,28 +42,23 @@ codegen-units = 1
 bytes = "=0.3.0"
 log = "=0.3.6"
 log-panics = "=1.1.0"
-mio = "=0.6.2"
-regex = "=0.2.1"
 slab = "=0.3.0"
-shuteye = "=0.2.0"
 simple_logger = "=0.4.0"
-tiny_http = "=0.5.7"
-tic = "=0.1.1"
-time = "=0.1.35"
+time = "=0.1.36"
 
 [dependencies.rpcperf_request]
 path = "./lib/request"
-version = "=1.3.1"
+version = "=1.4.0"
 
 [dependencies.rpcperf_cfgtypes]
 path = "./lib/cfgtypes"
-version = "=0.1.1"
+version = "=0.1.2"
 
 [dependencies.rpcperf_common]
 path = "./lib/common"
-version = "=0.1.0"
+version = "=0.2.0"
 
 [features]
-asm = [ "tic/asm" ]
+asm = [ "rpcperf_common/asm" ]
 default = []
 unstable = []

--- a/configs/mixed_workload.toml
+++ b/configs/mixed_workload.toml
@@ -2,6 +2,10 @@
 # gets and sets occur on a 3byte keyspace with set injecting 4 byte values
 # read/write 80%/20% at 50kqps aggregate
 
+[general]
+request_timeout = 200
+connect_timeout = 500
+
 [[workload]]
 name = "get"
 method = "get"

--- a/lib/cfgtypes/Cargo.toml
+++ b/lib/cfgtypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_cfgtypes"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_common"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 [dependencies]
@@ -8,9 +8,15 @@ byteorder = "=1.0.0"
 crc = "=1.2.0"
 getopts = "=0.2.14"
 log = "=0.3.6"
+mio = "=0.6.4"
 mpmc = "=0.1.2"
 pad = "=0.1.4"
 rand = "=0.3.15"
 ratelimit = "=0.3.1"
 shuteye = "=0.2.0"
+tic = "=0.1.3"
 toml = "=0.2.1"
+
+[features]
+asm = [ "tic/asm" ]
+default = []

--- a/lib/common/src/lib.rs
+++ b/lib/common/src/lib.rs
@@ -16,11 +16,13 @@
 extern crate byteorder;
 extern crate crc;
 extern crate getopts;
+extern crate mio;
 extern crate mpmc;
 extern crate pad;
 extern crate ratelimit;
 extern crate toml;
 extern crate rand;
+extern crate tic;
 
 pub mod random {
     pub use rand::*;
@@ -43,5 +45,57 @@ pub mod limits {
 pub mod config {
     pub use toml::*;
 }
+pub mod async {
+    pub use mio::{channel, tcp, timer};
+    pub use mio::{Evented, Event, Events, Poll, PollOpt, Ready, Token};
+    pub use mpmc::Queue;
+}
+pub mod stats {
+    pub use tic::*;
+    use std::fmt;
 
-pub use mpmc::Queue as Queue;
+    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    pub enum Stat {
+        ResponseOk,
+        ResponseError,
+        ResponseTimeout,
+        ResponseOkHit,
+        ResponseOkMiss,
+        ConnectOk,
+        ConnectError,
+        ConnectTimeout,
+        RequestSent,
+        RequestPrepared,
+        SocketRead,
+        SocketWrite,
+        SocketFlush,
+        SocketClose,
+        SocketCreate,
+        Window,
+    }
+
+    impl fmt::Display for Stat {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match *self {
+                Stat::Window => write!(f, "window"),
+                Stat::ResponseOk => write!(f, "response_ok"),
+                Stat::ResponseError => write!(f, "response_error"),
+                Stat::ResponseTimeout => write!(f, "response_timeout"),
+                Stat::ResponseOkHit => write!(f, "response_ok_hit"),
+                Stat::ResponseOkMiss => write!(f, "response_ok_miss"),
+                Stat::ConnectOk => write!(f, "connect_ok"),
+                Stat::ConnectError => write!(f, "connect_error"),
+                Stat::ConnectTimeout => write!(f, "connect_timeout"),
+                Stat::RequestSent => write!(f, "request_sent"),
+                Stat::RequestPrepared => write!(f, "request_prepared"),
+                Stat::SocketRead => write!(f, "socket_read"),
+                Stat::SocketWrite => write!(f, "socket_write"),
+                Stat::SocketFlush => write!(f, "socket_flush"),
+                Stat::SocketClose => write!(f, "socket_close"),
+                Stat::SocketCreate => write!(f, "socket_create"),
+            }
+        }
+    }
+}
+
+pub use mpmc::Queue;

--- a/lib/echo/Cargo.toml
+++ b/lib/echo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_echo"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/memcache/Cargo.toml
+++ b/lib/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_memcache"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/memcache/src/lib.rs
+++ b/lib/memcache/src/lib.rs
@@ -131,38 +131,57 @@ impl ProtocolGen for MemcacheCommand {
                 level.regen();
                 gen::verbosity(level.value.string.parse().unwrap_or(0)).into_bytes()
             }
-            MemcacheCommand::Version => {
-                gen::version().into_bytes()
-            }
-            MemcacheCommand::Quit => {
-                gen::quit().into_bytes()
-            }
+            MemcacheCommand::Version => gen::version().into_bytes(),
+            MemcacheCommand::Quit => gen::quit().into_bytes(),
             MemcacheCommand::Touch(ref mut key, ref mut ttl) => {
                 key.regen();
                 ttl.regen();
-                gen::touch(key.value.string.as_str(), Some(ttl.value.string.parse().unwrap_or(0))).into_bytes()
+                gen::touch(key.value.string.as_str(),
+                           Some(ttl.value.string.parse().unwrap_or(0)))
+                    .into_bytes()
             }
             MemcacheCommand::Delete(ref mut key) => {
                 key.regen();
                 gen::delete(key.value.string.as_str()).into_bytes()
             }
             MemcacheCommand::Cas(ref mut key, ref mut value, ref mut cas) => {
-                gen::cas(key.value.string.as_str(), value.value.string.as_str(), None, None, cas.value.string.parse().unwrap_or(0)).into_bytes()
+                gen::cas(key.value.string.as_str(),
+                         value.value.string.as_str(),
+                         None,
+                         None,
+                         cas.value.string.parse().unwrap_or(0))
+                    .into_bytes()
             }
             MemcacheCommand::Replace(ref mut key, ref mut value) => {
-                gen::replace(key.value.string.as_str(), value.value.string.as_str(), None, None).into_bytes()
+                gen::replace(key.value.string.as_str(),
+                             value.value.string.as_str(),
+                             None,
+                             None)
+                    .into_bytes()
             }
             MemcacheCommand::Append(ref mut key, ref mut value) => {
-                gen::append(key.value.string.as_str(), value.value.string.as_str(), None, None).into_bytes()
+                gen::append(key.value.string.as_str(),
+                            value.value.string.as_str(),
+                            None,
+                            None)
+                    .into_bytes()
             }
             MemcacheCommand::Prepend(ref mut key, ref mut value) => {
-                gen::prepend(key.value.string.as_str(), value.value.string.as_str(), None, None).into_bytes()
+                gen::prepend(key.value.string.as_str(),
+                             value.value.string.as_str(),
+                             None,
+                             None)
+                    .into_bytes()
             }
             MemcacheCommand::Incr(ref mut key, ref mut value) => {
-                gen::incr(key.value.string.as_str(), value.value.string.parse().unwrap_or(1)).into_bytes()
+                gen::incr(key.value.string.as_str(),
+                          value.value.string.parse().unwrap_or(1))
+                    .into_bytes()
             }
             MemcacheCommand::Decr(ref mut key, ref mut value) => {
-                gen::decr(key.value.string.as_str(), value.value.string.parse().unwrap_or(1)).into_bytes()
+                gen::decr(key.value.string.as_str(),
+                          value.value.string.parse().unwrap_or(1))
+                    .into_bytes()
             }
         }
     }
@@ -252,7 +271,9 @@ fn extract_workload(i: usize, workload: &BTreeMap<String, Value>) -> CResult<Ben
             "verbosity" if ps.len() == 1 => MemcacheCommand::Verbosity(ps[0].clone()),
             "version" if ps.len() == 0 => MemcacheCommand::Version,
             "quit" if ps.len() == 0 => MemcacheCommand::Quit,
-            "cas" if ps.len() == 3 => MemcacheCommand::Cas(ps[0].clone(), ps[1].clone(), ps[2].clone()),
+            "cas" if ps.len() == 3 => {
+                MemcacheCommand::Cas(ps[0].clone(), ps[1].clone(), ps[2].clone())
+            }
             "replace" if ps.len() == 2 => MemcacheCommand::Replace(ps[0].clone(), ps[1].clone()),
             "append" if ps.len() == 2 => MemcacheCommand::Append(ps[0].clone(), ps[1].clone()),
             "prepend" if ps.len() == 2 => MemcacheCommand::Prepend(ps[0].clone(), ps[1].clone()),
@@ -260,7 +281,8 @@ fn extract_workload(i: usize, workload: &BTreeMap<String, Value>) -> CResult<Ben
             "decr" if ps.len() == 2 => MemcacheCommand::Decr(ps[0].clone(), ps[1].clone()),
             "touch" if ps.len() == 2 => MemcacheCommand::Touch(ps[0].clone(), ps[1].clone()),
             "delete" if ps.len() == 1 => MemcacheCommand::Delete(ps[0].clone()),
-            "get" | "gets" | "set" | "add" | "verbosity" | "version" | "quit" | "cas" | "replace" | "append" | "prepend" | "incr" | "decr" | "touch" | "delete" => {
+            "get" | "gets" | "set" | "add" | "verbosity" | "version" | "quit" | "cas" |
+            "replace" | "append" | "prepend" | "incr" | "decr" | "touch" | "delete" => {
                 return Err(format!("invalid number of params ({}) for method {}",
                                    ps.len(),
                                    method));

--- a/lib/ping/Cargo.toml
+++ b/lib/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_ping"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0"}
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0"}
 
 [profile.dev]
 opt-level = 0

--- a/lib/redis/Cargo.toml
+++ b/lib/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_redis"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/redis/src/lib.rs
+++ b/lib/redis/src/lib.rs
@@ -93,7 +93,9 @@ impl Command {
             }
             Command::Expire(ref mut p1, ref mut p2) => {
                 p1.regen();
-                gen::expire(p1.value.string.as_str(), p2.value.string.as_str().parse().unwrap()).into_bytes()
+                gen::expire(p1.value.string.as_str(),
+                            p2.value.string.as_str().parse().unwrap())
+                    .into_bytes()
             }
             Command::Incr(ref mut p1) => {
                 p1.regen();
@@ -153,8 +155,7 @@ impl ProtocolParseFactory for RedisParseFactory {
             vec![gen::flushall().into_bytes(), gen::select(&self.database).into_bytes()]
         } else {
             vec![gen::select(&self.database).into_bytes()]
-        }
-        )
+        })
     }
 
     fn name(&self) -> &str {
@@ -174,11 +175,10 @@ pub fn load_config(table: &BTreeMap<String, Value>, matches: &Matches) -> CResul
 
     let mut ws = Vec::new();
 
-    let database =
-            table.get("general")
-                .and_then(|k| k.as_table())
-                .and_then(|k| k.get("database"))
-                .and_then(|k| k.as_integer())
+    let database = table.get("general")
+        .and_then(|k| k.as_table())
+        .and_then(|k| k.get("database"))
+        .and_then(|k| k.as_integer())
         .unwrap_or(0) as u32;
 
     if let Some(&Value::Array(ref workloads)) = table.get("workload") {
@@ -244,7 +244,8 @@ fn extract_workload(workload: &BTreeMap<String, Value>) -> CResult<BenchmarkWork
             "decr" if ps.len() == 1 => Command::Decr(ps[0].clone()),
             "append" if ps.len() == 2 => Command::Append(ps[0].clone(), ps[1].clone()),
             "prepend" if ps.len() == 1 => Command::Prepend(ps[0].clone(), ps[1].clone()),
-            "get" | "set" | "hset" | "hget" | "del" | "expire" | "incr" | "decr" | "append" | "prepend" => {
+            "get" | "set" | "hset" | "hget" | "del" | "expire" | "incr" | "decr" | "append" |
+            "prepend" => {
                 return Err(format!("invalid number of params ({}) for method {}",
                                    ps.len(),
                                    method));

--- a/lib/request/Cargo.toml
+++ b/lib/request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_request"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
 license = "Apache-2.0"
@@ -14,13 +14,13 @@ readme = "README.md"
 
 [dependencies]
 log = "=0.3.6"
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0" }
-rpcperf_echo = { path = "../echo", version = "0.1.1" }
-rpcperf_memcache = { path = "../memcache", version = "0.2.0" }
-rpcperf_redis = { path = "../redis", version = "0.2.0" }
-rpcperf_ping = { path = "../ping", version = "0.1.1" }
-rpcperf_thrift = { path = "../thrift", version = "0.1.1" }
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
+rpcperf_echo = { path = "../echo", version = "0.1.2" }
+rpcperf_memcache = { path = "../memcache", version = "0.2.1" }
+rpcperf_redis = { path = "../redis", version = "0.2.1" }
+rpcperf_ping = { path = "../ping", version = "0.1.2" }
+rpcperf_thrift = { path = "../thrift", version = "0.1.2" }
 
 [profile.dev]
 opt-level = 0

--- a/lib/request/src/config.rs
+++ b/lib/request/src/config.rs
@@ -141,8 +141,11 @@ fn load_config_table(table: BTreeMap<String, Value>,
         if let Some(ipv6) = general.get("ipv6").and_then(|k| k.as_bool()) {
             config.ipv6 = ipv6;
         }
-        if let Some(timeout) = general.get("timeout").and_then(|k| k.as_integer()) {
+        if let Some(timeout) = general.get("request-timeout").and_then(|k| k.as_integer()) {
             config.timeout = Some(timeout as u64);
+        }
+        if let Some(v) = general.get("connect-timeout").and_then(|k| k.as_integer()) {
+            config.connect_timeout = Some(v as u64);
         }
     }
 
@@ -172,8 +175,12 @@ fn config_overrides(config: &mut BenchmarkConfig, matches: &Matches) -> Result<(
         config.duration = duration;
     }
 
-    if let Some(timeout) = try!(parse_opt("timeout", matches)) {
-        config.timeout = Some(timeout);
+    if let Some(t) = try!(parse_opt("request-timeout", matches)) {
+        config.timeout = Some(t);
+    }
+
+    if let Some(t) = try!(parse_opt("connect-timeout", matches)) {
+        config.connect_timeout = Some(t);
     }
 
     if matches.opt_present("tcp-nodelay") {

--- a/lib/request/src/lib.rs
+++ b/lib/request/src/lib.rs
@@ -29,6 +29,8 @@ extern crate rpcperf_thrift as thrift;
 pub mod config;
 pub mod workload;
 
+use common::stats::{Stat, Sender};
+
 use cfgtypes::ProtocolConfig;
 
 pub struct BenchmarkConfig {
@@ -41,6 +43,8 @@ pub struct BenchmarkConfig {
     pub ipv6: bool,
     pub timeout: Option<u64>,
     pub protocol_config: ProtocolConfig,
+    stats: Option<Sender<Stat>>,
+    connect_timeout: Option<u64>,
 }
 
 impl BenchmarkConfig {
@@ -55,6 +59,42 @@ impl BenchmarkConfig {
             ipv6: true,
             timeout: None,
             protocol_config: protocol,
+            stats: None,
+            connect_timeout: None,
         }
+    }
+
+    pub fn set_poolsize(&mut self, connections: usize) -> &Self {
+        self.connections = connections;
+        self
+    }
+
+    pub fn set_threads(&mut self, threads: usize) -> &Self {
+        self.threads = threads;
+        self
+    }
+
+    pub fn set_duration(&mut self, seconds: usize) -> &Self {
+        self.duration = seconds;
+        self
+    }
+
+    pub fn set_windows(&mut self, count: usize) -> &Self {
+        self.windows = count;
+        self
+    }
+
+    pub fn set_tcp_nodelay(&mut self, enabled: bool) -> &Self {
+        self.tcp_nodelay = enabled;
+        self
+    }
+
+    pub fn set_stats(&mut self, sender: Sender<Stat>) -> &Self {
+        self.stats = Some(sender);
+        self
+    }
+
+    pub fn connect_timeout(&self) -> Option<u64> {
+        self.connect_timeout
     }
 }

--- a/lib/thrift/Cargo.toml
+++ b/lib/thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcperf_thrift"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>",
            "Bryce Anderson <bryce.anderson22@gmail.com"]
 
@@ -14,8 +14,8 @@ repository = "https://github.com/twitter/rpc-perf"
 readme = "README.md"
 
 [dependencies]
-rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.1" }
-rpcperf_common = { path = "../common", version = "0.1.0" }
+rpcperf_cfgtypes = { path = "../cfgtypes", version = "0.1.2" }
+rpcperf_common = { path = "../common", version = "0.2.0" }
 
 [profile.dev]
 opt-level = 0

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -31,11 +31,16 @@ impl log::Log for SimpleLogger {
             let ms = format!("{:.*}",
                              3,
                              ((time::precise_time_ns() % 1_000_000_000) / 1_000_000));
+            let target = if record.metadata().level() >= LogLevel::Debug {
+                record.target()
+            } else {
+                "rpc-perf"
+            };
             println!("{}.{} {:<5} [{}] {}",
                      time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
                      ms.pad(3, '0', Alignment::Right, true),
                      record.level().to_string(),
-                     "rpc-perf",
+                     target,
                      record.args());
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -26,9 +26,9 @@ pub enum InternetProtocol {
 impl fmt::Debug for InternetProtocol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            InternetProtocol::IpV4 => write!(f, "IP::v4"),
-            InternetProtocol::IpV6 => write!(f, "IP::v6"),
-            InternetProtocol::Any => write!(f, "IP::Any"),
+            InternetProtocol::IpV4 => write!(f, "IPv4"),
+            InternetProtocol::IpV6 => write!(f, "IPv6"),
+            InternetProtocol::Any => write!(f, "IP"),
         }
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -13,130 +13,105 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-extern crate shuteye;
-extern crate tic;
-extern crate tiny_http;
+use std::process::exit;
+use common::stats::{Meters, Percentile, Receiver, Sample, Stat};
 
-use std::fmt;
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Status {
-    Error,
-    Hit,
-    Miss,
-    Ok,
-    Closed,
-    Timeout,
+pub fn meters_delta(t0: &Meters<Stat>, t1: &Meters<Stat>, stat: &Stat) -> u64 {
+    *t1.get_count(stat).unwrap_or(&0) - *t0.get_count(stat).unwrap_or(&0)
 }
 
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Status::Ok => write!(f, "ok"),
-            Status::Error => write!(f, "error"),
-            Status::Hit => write!(f, "hit"),
-            Status::Miss => write!(f, "miss"),
-            Status::Closed => write!(f, "closed"),
-            Status::Timeout => write!(f, "timeout"),
-        }
-    }
-}
-
-pub fn run(mut receiver: tic::Receiver<Status>, windows: usize, duration: usize) {
+pub fn run(mut receiver: Receiver<Stat>, windows: usize) {
 
     let mut window = 0;
     let mut warmup = true;
 
-    let mut total = 0;
-    let mut ok = 0;
-    let mut hit = 0;
-    let mut miss = 0;
-    let mut error = 0;
-    let mut closed = 0;
-    let mut timeout = 0;
+    let clocksource = receiver.get_clocksource().clone();
+    let mut sender = receiver.get_sender().clone();
+    sender.set_batch_size(1);
+
+    let mut t0 = clocksource.counter();
+    let mut m0 = receiver.clone_meters();
 
     debug!("stats: collection ready");
     loop {
         receiver.run_once();
-        let meters = receiver.clone_meters();
-
-        let &new_ok = meters.get_count(&Status::Ok).unwrap_or(&0);
-        let &new_hit = meters.get_count(&Status::Hit).unwrap_or(&0);
-        let &new_miss = meters.get_count(&Status::Miss).unwrap_or(&0);
-        let &new_error = meters.get_count(&Status::Error).unwrap_or(&0);
-        let &new_closed = meters.get_count(&Status::Closed).unwrap_or(&0);
-        let &new_timeout = meters.get_count(&Status::Timeout).unwrap_or(&0);
-        let &new_total = meters.get_combined_count().unwrap_or(&0);
+        let t1 = clocksource.counter();
+        let _ = sender.send(Sample::new(t0, t1, Stat::Window));
+        let m1 = receiver.clone_meters();
 
         if warmup {
             info!("-----");
+            if meters_delta(&m0, &m1, &Stat::ConnectOk) == 0 {
+                error!("No connections established. Please check that server(s) are available");
+                exit(1);
+            }
             info!("Warmup complete");
             warmup = false;
         } else {
-            let rate = (new_total - total) as f64 / duration as f64;
+            let responses = meters_delta(&m0, &m1, &Stat::ResponseOk) +
+                           meters_delta(&m0, &m1, &Stat::ResponseError);
 
-            let t = (new_total - total) as f64;
-            let success_rate = if t > 0.0 {
-                100.0 * (t - ((new_error - error) + (new_timeout - timeout)) as f64) / t
+            let rate = responses as f64 / ((clocksource.convert(t1) - clocksource.convert(t0)) as f64 / 1_000_000_000.0);
+
+            let success_rate = if responses > 0 {
+                100.0 * (responses - meters_delta(&m0, &m1, &Stat::ResponseError)) as f64 /
+                (responses + meters_delta(&m0, &m1, &Stat::ResponseTimeout)) as f64
             } else {
                 0.0
             };
 
-            let &new_hit = meters.get_count(&Status::Hit).unwrap_or(&0);
-            let &new_miss = meters.get_count(&Status::Miss).unwrap_or(&0);
-            let t = ((new_hit - hit) + (new_miss - miss)) as f64;
-            let hit_rate = if t > 0.0 {
-                100.0 * (new_hit - hit) as f64 / t
+            let hit = meters_delta(&m0, &m1, &Stat::ResponseOkHit);
+            let miss = meters_delta(&m0, &m1, &Stat::ResponseOkMiss);
+
+            let hit_rate = if (hit + miss) > 0 {
+                100.0 * hit as f64 / (hit + miss) as f64
             } else {
                 0.0
             };
 
             info!("-----");
-            info!("Window: {}", window);
-            info!("Requests: Total: {} Timeout: {}",
-                  (new_total - total),
-                  (new_timeout - timeout));
-            info!("Responses: Ok: {} Error: {} Closed: {} Hit: {} Miss: {}",
-                  (new_ok - ok),
-                  (new_error - error),
-                  (new_closed - closed),
-                  (new_hit - hit),
-                  (new_miss - miss));
-            info!("Rate: {:.*} rps Success: {:.*} % Hitrate: {:.*} %",
+            info!("Window: {}", *m1.get_count(&Stat::Window).unwrap_or(&0));
+            let inflight = *m1.get_count(&Stat::RequestSent).unwrap_or(&0) as i64 -
+                           *m1.get_count(&Stat::ResponseOk).unwrap_or(&0) as i64 -
+                           *m1.get_count(&Stat::ResponseError).unwrap_or(&0) as i64 -
+                           *m1.get_count(&Stat::ResponseTimeout).unwrap_or(&0) as i64;
+            let open = *m1.get_count(&Stat::ConnectOk).unwrap_or(&0) as i64 -
+                       *m1.get_count(&Stat::ConnectError).unwrap_or(&0) as i64 -
+                       *m1.get_count(&Stat::ConnectTimeout).unwrap_or(&0) as i64 -
+                       *m1.get_count(&Stat::SocketClose).unwrap_or(&0) as i64;
+            info!("Connections: Ok: {} Error: {} Timeout: {} Open: {}",
+                  meters_delta(&m0, &m1, &Stat::ConnectOk),
+                  meters_delta(&m0, &m1, &Stat::ConnectError),
+                  meters_delta(&m0, &m1, &Stat::ConnectTimeout),
+                  open);
+            info!("Sockets: Create: {} Close: {} Read: {} Write: {} Flush: {}",
+                  meters_delta(&m0, &m1, &Stat::SocketCreate),
+                  meters_delta(&m0, &m1, &Stat::SocketClose),
+                  meters_delta(&m0, &m1, &Stat::SocketRead),
+                  meters_delta(&m0, &m1, &Stat::SocketWrite),
+                  meters_delta(&m0, &m1, &Stat::SocketFlush));
+            info!("Requests: Sent: {} Prepared: {} In-Flight: {}",
+                  meters_delta(&m0, &m1, &Stat::RequestSent),
+                  meters_delta(&m0, &m1, &Stat::RequestPrepared),
+                  inflight);
+            info!("Responses: Ok: {} Error: {} Timeout: {} Hit: {} Miss: {}",
+                  meters_delta(&m0, &m1, &Stat::ResponseOk),
+                  meters_delta(&m0, &m1, &Stat::ResponseError),
+                  meters_delta(&m0, &m1, &Stat::ResponseTimeout),
+                  meters_delta(&m0, &m1, &Stat::ResponseOkHit),
+                  meters_delta(&m0, &m1, &Stat::ResponseOkMiss));
+            info!("Rate: {:.*} rps Success: {:.*} % Hit Rate: {:.*} %",
                   2,
                   rate,
                   2,
                   success_rate,
                   2,
                   hit_rate);
-            info!("Latency: min: {} ns max: {} ns",
-                    meters.get_combined_percentile(
-                        tic::Percentile("min".to_owned(), 0.00)).unwrap_or(&0),
-                    meters.get_combined_percentile(
-                        tic::Percentile("max".to_owned(), 100.00)).unwrap_or(&0),
-                );
-            info!("Percentiles: p50: {} ns p90: {} ns p99: {} ns p999: {} ns p9999: {} ns",
-                    meters.get_combined_percentile(
-                        tic::Percentile("p50".to_owned(), 50.0)).unwrap_or(&0),
-                    meters.get_combined_percentile(
-                        tic::Percentile("p90".to_owned(), 90.0)).unwrap_or(&0),
-                    meters.get_combined_percentile(
-                        tic::Percentile("p99".to_owned(), 99.0)).unwrap_or(&0),
-                    meters.get_combined_percentile(
-                        tic::Percentile("p999".to_owned(), 99.9)).unwrap_or(&0),
-                    meters.get_combined_percentile(
-                        tic::Percentile("p9999".to_owned(), 99.99)).unwrap_or(&0),
-                );
+            display_percentiles(&m1, &Stat::ResponseOk, "Response OK");
         }
 
-        error = new_error;
-        total = new_total;
-        ok = new_ok;
-        timeout = new_timeout;
-        closed = new_closed;
-        hit = new_hit;
-        miss = new_miss;
-
+        m0 = m1;
+        t0 = t1;
         window += 1;
 
         if window > windows {
@@ -145,4 +120,24 @@ pub fn run(mut receiver: tic::Receiver<Status>, windows: usize, duration: usize)
             break;
         }
     }
+}
+
+fn display_percentiles(meters: &Meters<Stat>, stat: &Stat, label: &str) {
+    info!("Percentiles: {} (us): min: {} p50: {} p90: {} p99: {} p999: {} p9999: {} max: {}",
+                    label,
+                    meters.get_percentile(stat,
+                        Percentile("min".to_owned(), 0.0)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("p50".to_owned(), 50.0)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("p90".to_owned(), 90.0)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("p99".to_owned(), 99.0)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("p999".to_owned(), 99.9)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("p9999".to_owned(), 99.99)).unwrap_or(&0) / 1000,
+                    meters.get_percentile(stat,
+                        Percentile("max".to_owned(), 100.0)).unwrap_or(&0) / 1000,
+                );
 }


### PR DESCRIPTION
change request dispatch

- workloads push directly onto client MPSC queues
- reduces CPU consumption and threads required

cache DNS lookups

- add basic per-connection caching of DNS lookups to avoid overwhelming DNS servers under heavy timeout/reconnect

refactor stats

-  refactoring the stats so we can gather stats on internal metrics
-  breaking: some stats have changed
-  bugfix: stats library (tic) was stalling out using mio channels. updated to tic 0.1.3 which uses MPMC queue with sender batching
