### PR TITLE
remove build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ readme = "README.md"
 
 exclude = ["./lib"]
 
-build = "build.rs"
-
 [profile.dev]
 opt-level = 0
 debug = true

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-#[cfg(feature="git-version")]
-extern crate git_build_version;
-#[cfg(feature="git-version")]
-const PACKAGE_TOP_DIR: &'static str = ".";
-
-fn main() {
-    #[cfg(feature="git-version")]
-    git_build_version::write_version(PACKAGE_TOP_DIR).expect("Saving git version");
-}


### PR DESCRIPTION
- no longer need build.rs, as all functions handled by normal cargo build