### PR TITLE
Cargo.toml remove exlude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ repository = "https://github.com/twitter/rpc-perf"
 
 readme = "README.md"
 
-exclude = ["./lib"]
-
 [profile.dev]
 opt-level = 0
 debug = true


### PR DESCRIPTION
- exclude is no-longer needed in Cargo.toml, we should be okay with the defaults