### PR TITLE
fix: trace file

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -68,7 +68,7 @@ pub fn stats_receiver_init(config: &BenchmarkConfig,
     }
 
     if let Some(t) = trace {
-        stats_receiver.add_interest(Interest::Waterfall(Stat::ResponseOk, t));
+        stats_receiver.add_interest(Interest::Trace(Stat::ResponseOk, t));
     }
 
     stats_receiver


### PR DESCRIPTION
- trace file was incorrectly registered as a Waterfall interest, resulting in saving PNG waterfall instead of a trace file