### PR TITLE
testing: cargo-fuzz and clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,77 @@ rust:
   - stable
   - beta
   - nightly
-os:
-  - linux
-cache: cargo
-before_script: (cargo install rustfmt || true)
+os: linux
+dist: trusty
+sudo: required
+env: RUST_BACKTRACE=1
+cache:
+  directories:
+  - $HOME/.cargo
+  - $TRAVIS_BUILD_DIR/target
+  - $TRAVIS_BUILD_DIR/fuzz/target
+  - $TRAVIS_BUILD_DIR/fuzz/corpus
 script:
 - cargo build --verbose
-- cargo build --release --verbose
 - cargo test --verbose
+- cargo build --release --verbose
 - cargo test --release --verbose
-- cargo fmt -- --write-mode=diff
 matrix:
   include:
     - os: linux
+      rust: stable
+      env: TYPE=rustfmt RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install rustfmt || true)
+        - cargo fmt -- --write-mode=diff
+    - os: linux
       rust: nightly
+      env: TYPE=bench RUST_BACKTRACE=1
       script: cargo bench --features unstable
     - os: linux
       rust: nightly
+      env: TYPE=features_asm RUST_BACKTRACE=1
       script: cargo build --features asm --release
+    - os: linux
+      rust: nightly
+      env: TYPE=clippy RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install clippy || true)
+        - cargo clippy
+    - os: linux
+      rust: nightly
+      env: TYPE=fuzzer_codec_echo RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_echo -- -max_total_time=300
+        - sudo chown -R travis $HOME/.cargo
+    - os: linux
+      rust: nightly
+      env: TYPE=fuzzer_codec_memcache RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_memcache -- -max_total_time=300
+        - sudo chown -R travis $HOME/.cargo
+    - os: linux
+      rust: nightly
+      env: TYPE=fuzzer_codec_ping RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_ping -- -max_total_time=300
+        - sudo chown -R travis $HOME/.cargo
+    - os: linux
+      rust: nightly
+      env: TYPE=fuzzer_codec_redis RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_redis -- -max_total_time=300
+        - sudo chown -R travis $HOME/.cargo
+    - os: linux
+      rust: nightly
+      env: TYPE=fuzzer_codec_thrift RUST_BACKTRACE=1
+      script:
+        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_thrift -- -max_total_time=300
+        - sudo chown -R travis $HOME/.cargo
   allow_failures:
     - rust: nightly

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1,0 +1,614 @@
+[root]
+name = "rpc-perf-fuzz"
+version = "0.0.1"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "adler32"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "allan"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ascii"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "chunked_transfer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clocksource"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crc"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "deflate"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "heatmap"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "histogram"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hsl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "inflate"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "iovec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazycell"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.1.0"
+source = "git+https://github.com/rust-fuzz/libfuzzer-sys.git#36a3928eef5c3c38eb0f251962395bb510c39d46"
+dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log-panics"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mio"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mpmc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "net2"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "odds"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pad"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "png"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deflate 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ratelimit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rusttype"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shuteye"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "simple_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slab"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stb_truetype"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tic"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "allan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clocksource 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heatmap 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "waterfall 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "waterfall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heatmap 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum adler32 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff33fe13a08dbce05bcefa2c68eea4844941437e33d6f808240b54d7157b9cd"
+"checksum allan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa005009b04f960d73beb2119ea84db3a03bfd3ef22f487eff52b660687de5a4"
+"checksum arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "699e63a93b79d717e8c3b5eb1b28b7780d0d6d9e59a72eb769291c83b0c8dc67"
+"checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
+"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
+"checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
+"checksum clocksource 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52b7f1ed402ddda326c2e16028ca283f3ed931e7cc051d5ab9a635b1d88d320b"
+"checksum crc 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541a7a4936092a4dac8b3a1dc1abc264372e0ce1e7ab712dfe0484374f5a2b7b"
+"checksum deflate 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8f39474a23b492b7ec97604c7828abd05771b28ed03cac0c6b884e79f9980283"
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
+"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum heatmap 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08498e2ed1798a9705476e70aab9ac4d392dae615695e6daac462585218433a9"
+"checksum histogram 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b336517dec01c1424711830db4f752ace81ee0459ef37caf9b821932b2f2e59"
+"checksum hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "575fb7f1167f3b88ed825e90eb14918ac460461fdeaa3965c6a50951dee1c970"
+"checksum inflate 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1238524675af3938a7c74980899535854b88ba07907bb1c944abe5b8fc437e5"
+"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
+"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
+"checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
+"checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
+"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
+"checksum log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26bbb657dd8a31b920792fba3fc60f2c18e9477931c0e01afed98116aa0056a7"
+"checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
+"checksum mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6d19442734abd7d780b981c590c325680d933e99795fe1f693f0686c9ed48022"
+"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e93e6c806a89abce6b59d120fd62cc9e424afc532453c5ce97328127171dda69"
+"checksum net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bc01404e7568680f1259aa5729539f221cb1e6d047a0d9053cab4be8a73b5d67"
+"checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
+"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
+"checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
+"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
+"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
+"checksum pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d1bf3336e626b898e7263790d432a711d4277e22faea20dd9f70e0cab268fa58"
+"checksum png 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48f397b84083c2753ba53c7b56ad023edb94512b2885ffe227c66ff7edb61868"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum ratelimit 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59051db7d98ac50dbd1f174badf73916e74ea8085c0328236dac17b5ad3d3a31"
+"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rusttype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07b8848db3b5b5ba97020c6a756c0fdf2dbf2ad7c0d06aa4344a3f2f49c3fe17"
+"checksum shuteye 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fae018891baadd06ff0281ff137ccd1641044d9bb9498b1138ffecf28f30172"
+"checksum simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a3b341928cec79e536fe62b75bfe2e35891a5e65801ebfbd2741dddf7d7fac"
+"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
+"checksum stb_truetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf3270840fc9de208d63e836eb3fdebb85379e7532f42f1b2cbd505fb6fda08"
+"checksum tic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01d42879bf769123db0a94c85eb0b64a0b0a50f74d4d2fb2d30088ab023dca60"
+"checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "016f040cfc9b5be610de3619eaaa57017fa0b0b678187327bde75fc146e2a41f"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)" = "cbaa8377a162d88e7d15db0cf110c8523453edcbc5bc66d2b6fffccffa34a068"
+"checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
+"checksum waterfall 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d064d35e8d8167949da128367d18338025e0f752f7f1783c04bc41017a72026d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,79 @@
+
+[package]
+name = "rpc-perf-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+byteorder = "=1.0.0"
+bytes = "=0.3.0"
+crc = "=1.2.0"
+getopts = "=0.2.14"
+log = "=0.3.7"
+log-panics = "=1.1.0"
+mio = "=0.6.7"
+mpmc = "=0.1.2"
+pad = "=0.1.4"
+rand = "=0.3.15"
+ratelimit = "=0.3.1"
+shuteye = "=0.2.0"
+slab = "=0.3.0"
+simple_logger = "=0.4.0"
+tic = "=0.2.0"
+time = "=0.1.37"
+toml = "=0.2.1"
+
+[profile.dev]
+opt-level = 0
+debug = true
+rpath = false
+lto = false
+debug-assertions = true
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+debug = true
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[profile.release]
+opt-level = 3
+debug = true
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzzer_codec_echo"
+path = "fuzzers/fuzzer_codec_echo.rs"
+
+[[bin]]
+name = "fuzzer_codec_memcache"
+path = "fuzzers/fuzzer_codec_memcache.rs"
+
+[[bin]]
+name = "fuzzer_codec_ping"
+path = "fuzzers/fuzzer_codec_ping.rs"
+
+[[bin]]
+name = "fuzzer_codec_redis"
+path = "fuzzers/fuzzer_codec_redis.rs"
+
+[[bin]]
+name = "fuzzer_codec_thrift"
+path = "fuzzers/fuzzer_codec_thrift.rs"

--- a/fuzz/fuzzers/fuzzer_codec_echo.rs
+++ b/fuzz/fuzzers/fuzzer_codec_echo.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+#[macro_use]
+extern crate log;
+extern crate bytes;
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mio;
+extern crate mpmc;
+extern crate pad;
+extern crate time;
+extern crate rand;
+extern crate ratelimit;
+extern crate slab;
+extern crate tic;
+extern crate toml;
+
+use std::str;
+
+#[path = "../../src/cfgtypes/mod.rs"]
+mod cfgtypes;
+
+#[path = "../../src/codec/mod.rs"]
+mod codec;
+
+use cfgtypes::*;
+use codec::echo::EchoParser;
+
+//ProtocolParseFactory
+fuzz_target!(|data: &[u8]| {
+                 let parser = EchoParser;
+                 let _ = parser.parse(data);
+             });

--- a/fuzz/fuzzers/fuzzer_codec_memcache.rs
+++ b/fuzz/fuzzers/fuzzer_codec_memcache.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+#[macro_use]
+extern crate log;
+extern crate bytes;
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mio;
+extern crate mpmc;
+extern crate pad;
+extern crate time;
+extern crate rand;
+extern crate ratelimit;
+extern crate slab;
+extern crate tic;
+extern crate toml;
+
+use std::str;
+
+#[path = "../../src/cfgtypes/mod.rs"]
+mod cfgtypes;
+
+#[path = "../../src/codec/mod.rs"]
+mod codec;
+
+use cfgtypes::*;
+use codec::memcache::MemcacheParser;
+
+//ProtocolParseFactory
+fuzz_target!(|data: &[u8]| {
+                 let parser = MemcacheParser;
+                 let _ = parser.parse(data);
+             });

--- a/fuzz/fuzzers/fuzzer_codec_ping.rs
+++ b/fuzz/fuzzers/fuzzer_codec_ping.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+#[macro_use]
+extern crate log;
+extern crate bytes;
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mio;
+extern crate mpmc;
+extern crate pad;
+extern crate time;
+extern crate rand;
+extern crate ratelimit;
+extern crate slab;
+extern crate tic;
+extern crate toml;
+
+use std::str;
+
+#[path = "../../src/cfgtypes/mod.rs"]
+mod cfgtypes;
+
+#[path = "../../src/codec/mod.rs"]
+mod codec;
+
+use cfgtypes::*;
+use codec::ping::Ping;
+
+//ProtocolParseFactory
+fuzz_target!(|data: &[u8]| {
+                 let parser = Ping;
+                 let _ = parser.parse(data);
+             });

--- a/fuzz/fuzzers/fuzzer_codec_redis.rs
+++ b/fuzz/fuzzers/fuzzer_codec_redis.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+#[macro_use]
+extern crate log;
+extern crate bytes;
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mio;
+extern crate mpmc;
+extern crate pad;
+extern crate time;
+extern crate rand;
+extern crate ratelimit;
+extern crate slab;
+extern crate tic;
+extern crate toml;
+
+use std::str;
+
+#[path = "../../src/cfgtypes/mod.rs"]
+mod cfgtypes;
+
+#[path = "../../src/codec/mod.rs"]
+mod codec;
+
+use cfgtypes::*;
+use codec::redis::RedisParse;
+
+//ProtocolParseFactory
+fuzz_target!(|data: &[u8]| {
+                 let parser = RedisParse;
+                 let _ = parser.parse(data);
+             });

--- a/fuzz/fuzzers/fuzzer_codec_thrift.rs
+++ b/fuzz/fuzzers/fuzzer_codec_thrift.rs
@@ -1,0 +1,35 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+#[macro_use]
+extern crate log;
+extern crate bytes;
+extern crate byteorder;
+extern crate crc;
+extern crate getopts;
+extern crate mio;
+extern crate mpmc;
+extern crate pad;
+extern crate time;
+extern crate rand;
+extern crate ratelimit;
+extern crate slab;
+extern crate tic;
+extern crate toml;
+
+use std::str;
+
+#[path = "../../src/cfgtypes/mod.rs"]
+mod cfgtypes;
+
+#[path = "../../src/codec/mod.rs"]
+mod codec;
+
+use cfgtypes::*;
+use codec::thrift::config::ThriftParse;
+
+//ProtocolParseFactory
+fuzz_target!(|data: &[u8]| {
+                 let parser = ThriftParse;
+                 let _ = parser.parse(data);
+             });

--- a/src/codec/echo/mod.rs
+++ b/src/codec/echo/mod.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use toml::Value;
 
-struct EchoParser;
+pub struct EchoParser;
 
 struct EchoGen {
     value: Parameter<EchoData>,

--- a/src/codec/memcache/mod.rs
+++ b/src/codec/memcache/mod.rs
@@ -50,7 +50,7 @@ struct MemcacheParserFactory {
     flush: bool,
 }
 
-struct MemcacheParser;
+pub struct MemcacheParser;
 
 #[derive(Clone, Debug)]
 struct CacheData {
@@ -91,8 +91,11 @@ impl ProtocolParseFactory for MemcacheParserFactory {
 
 impl ProtocolParse for MemcacheParser {
     fn parse(&self, bytes: &[u8]) -> ParsedResponse {
-        let s = str::from_utf8(bytes).unwrap();
-        parse::parse_response(s)
+        if let Ok(s) = str::from_utf8(bytes) {
+            parse::parse_response(s)
+        } else {
+            ParsedResponse::Invalid
+        }
     }
 }
 

--- a/src/codec/memcache/parse.rs
+++ b/src/codec/memcache/parse.rs
@@ -19,6 +19,10 @@ pub fn parse_response(response: &str) -> ParsedResponse {
 
     let mut lines: Vec<&str> = response.split("\r\n").collect();
 
+    if lines.len() < 2 {
+        return ParsedResponse::Incomplete;
+    }
+
     // expect an empty line from the split
     if lines[lines.len() - 1] == "" {
         let _ = lines.pop();
@@ -27,6 +31,10 @@ pub fn parse_response(response: &str) -> ParsedResponse {
     }
 
     let tokens: Vec<&str> = lines[0].split_whitespace().collect();
+
+    if tokens.len() < 1 {
+        return ParsedResponse::Incomplete;
+    }
 
     // one line responses can be special cased
     if lines.len() == 1 {

--- a/src/codec/ping/mod.rs
+++ b/src/codec/ping/mod.rs
@@ -25,7 +25,7 @@ use std::str;
 use std::sync::Arc;
 use toml::Value;
 
-struct Ping;
+pub struct Ping;
 
 impl ProtocolGen for Ping {
     fn generate_message(&mut self) -> Vec<u8> {
@@ -49,8 +49,11 @@ impl ProtocolParseFactory for Ping {
 
 impl ProtocolParse for Ping {
     fn parse(&self, bytes: &[u8]) -> ParsedResponse {
-        let s = str::from_utf8(bytes).unwrap();
-        parse::parse_response(s)
+        if let Ok(s) = str::from_utf8(bytes) {
+            parse::parse_response(s)
+        } else {
+            ParsedResponse::Invalid
+        }
     }
 }
 

--- a/src/codec/ping/parse.rs
+++ b/src/codec/ping/parse.rs
@@ -19,6 +19,10 @@ use cfgtypes::ParsedResponse;
 pub fn parse_response(response: &str) -> ParsedResponse {
     let mut lines: Vec<&str> = response.split("\r\n").collect();
 
+    if lines.len() < 2 {
+        return ParsedResponse::Incomplete;
+    }
+
     // expect an empty line from the split
     if lines[lines.len() - 1] == "" {
         let _ = lines.pop();

--- a/src/codec/redis/mod.rs
+++ b/src/codec/redis/mod.rs
@@ -118,7 +118,7 @@ impl Command {
     }
 }
 
-struct RedisParse;
+pub struct RedisParse;
 
 struct RedisParseFactory {
     flush: bool,
@@ -167,8 +167,11 @@ impl ProtocolParseFactory for RedisParseFactory {
 
 impl ProtocolParse for RedisParse {
     fn parse(&self, bytes: &[u8]) -> ParsedResponse {
-        let s = str::from_utf8(bytes).unwrap();
-        parse::parse_response(s)
+        if let Ok(s) = str::from_utf8(bytes) {
+            parse::parse_response(s)
+        } else {
+            ParsedResponse::Invalid
+        }
     }
 }
 

--- a/src/codec/redis/parse.rs
+++ b/src/codec/redis/parse.rs
@@ -27,9 +27,21 @@ pub fn parse_response(response: &str) -> ParsedResponse {
         return ParsedResponse::Incomplete;
     }
 
-    let (first_char, msg) = lines[0].split_at(1);
+    if lines.is_empty() {
+        return ParsedResponse::Incomplete;
+    }
 
-    match first_char {
+    let mut chars: Vec<char> = lines[0].chars().collect();
+
+    if chars.len() < 2 {
+        return ParsedResponse::Incomplete;
+    }
+
+    let first_char = chars.remove(0).to_string();
+    let msg: String = chars.into_iter().collect();
+    let msg = msg.as_str();
+
+    match first_char.as_str() {
         "+" => {
             // simple string
             // + simple string

--- a/src/codec/thrift/config.rs
+++ b/src/codec/thrift/config.rs
@@ -23,7 +23,7 @@ use cfgtypes::Value;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-struct ThriftParse;
+pub struct ThriftParse;
 struct ThriftParseFactory;
 
 struct ThriftGen {

--- a/src/codec/thrift/parse.rs
+++ b/src/codec/thrift/parse.rs
@@ -18,15 +18,23 @@ use byteorder::{BigEndian, ByteOrder};
 use cfgtypes::ParsedResponse;
 
 pub fn parse_response(response: &[u8]) -> ParsedResponse {
-    let bytes = response.len();
+    let bytes = response.len() as u32;
     if bytes > 4 {
         let length = BigEndian::read_u32(&response[0..4]);
 
-        if bytes as u32 == (length + 4_u32) {
-            return ParsedResponse::Ok;
+        match length.checked_add(4_u32) {
+            Some(b) => {
+                if b == bytes {
+                    ParsedResponse::Ok
+                } else {
+                    ParsedResponse::Incomplete
+                }
+            }
+            None => ParsedResponse::Invalid,
         }
+    } else {
+        ParsedResponse::Incomplete
     }
-    ParsedResponse::Incomplete
 }
 
 #[cfg(test)]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -230,10 +230,7 @@ impl Connection {
                     // read bytes from connection
                     trace!("read() bytes {}", n);
                     let mut buffer = buffer.flip();
-                    let _ = buffer
-                        .by_ref()
-                        .take(n as u64)
-                        .read_to_end(&mut response);
+                    let _ = buffer.by_ref().take(n as u64).read_to_end(&mut response);
                     trace!("read: {:?}", response);
                     self.buffer.rx = Some(buffer.flip());
                     self.stream = Some(s);

--- a/src/request/config.rs
+++ b/src/request/config.rs
@@ -132,14 +132,10 @@ fn load_config_table(table: &BTreeMap<String, Value>,
         if let Some(ipv6) = general.get("ipv6").and_then(|k| k.as_bool()) {
             config.ipv6 = ipv6;
         }
-        if let Some(v) = general
-               .get("request-timeout")
-               .and_then(|k| k.as_integer()) {
+        if let Some(v) = general.get("request-timeout").and_then(|k| k.as_integer()) {
             config.set_request_timeout(Some(v as u64));
         }
-        if let Some(v) = general
-               .get("connect-timeout")
-               .and_then(|k| k.as_integer()) {
+        if let Some(v) = general.get("connect-timeout").and_then(|k| k.as_integer()) {
             config.set_connect_timeout(Some(v as u64));
         }
     }

--- a/src/request/workload.rs
+++ b/src/request/workload.rs
@@ -98,8 +98,7 @@ impl Workload {
                 match self.queue[index].push(msg.take().unwrap()) {
                     Ok(_) => {
                         let t1 = self.clocksource.counter();
-                        let _ = self.stats
-                            .send(Sample::new(t0, t1, Stat::RequestPrepared));
+                        let _ = self.stats.send(Sample::new(t0, t1, Stat::RequestPrepared));
                         break;
                     }
                     Err(m) => {


### PR DESCRIPTION
- extend travis testing to provide coverage for clippy and cargo-fuzz
- currently leaving these tests as failures allowed, will make failing in future
- make the parser interfaces public to allow fuzzing
- fixes to the codecs for problems revealed in fuzzing