### PR TITLE
ci: benchmark comparison

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ rust:
 os: linux
 dist: trusty
 sudo: required
-env: RUST_BACKTRACE=1
+env: TYPE=default RUST_BACKTRACE=1
 cache:
   directories:
   - $HOME/.cargo
-  - $TRAVIS_BUILD_DIR/target
+  - $TRAVIS_BUILD_DIR/target/debug
+  - $TRAVIS_BUILD_DIR/target/release
+  - $TRAVIS_BUILD_DIR/target/benchcmp/target
   - $TRAVIS_BUILD_DIR/fuzz/target
   - $TRAVIS_BUILD_DIR/fuzz/corpus
 script:
@@ -24,7 +26,7 @@ matrix:
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install rustfmt || true)
+        - cargo install -f rustfmt
         - cargo fmt -- --write-mode=diff
     - os: linux
       rust: nightly
@@ -32,47 +34,51 @@ matrix:
       script: cargo bench --features unstable
     - os: linux
       rust: nightly
-      env: TYPE=features_asm RUST_BACKTRACE=1
+      env: TYPE=benchcmp RUST_BACKTRACE=1
+      script: cargo bench --features benchcmp
+    - os: linux
+      rust: nightly
+      env: TYPE=features RUST_BACKTRACE=1
       script: cargo build --features asm --release
     - os: linux
       rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install clippy || true)
+        - cargo install clippy -f
         - cargo clippy
     - os: linux
       rust: nightly
       env: TYPE=fuzzer_codec_echo RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - cargo install cargo-fuzz -f
         - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_echo -- -max_total_time=300
         - sudo chown -R travis $HOME/.cargo
     - os: linux
       rust: nightly
       env: TYPE=fuzzer_codec_memcache RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - cargo install cargo-fuzz -f
         - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_memcache -- -max_total_time=300
         - sudo chown -R travis $HOME/.cargo
     - os: linux
       rust: nightly
       env: TYPE=fuzzer_codec_ping RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - cargo install cargo-fuzz -f
         - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_ping -- -max_total_time=300
         - sudo chown -R travis $HOME/.cargo
     - os: linux
       rust: nightly
       env: TYPE=fuzzer_codec_redis RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - cargo install cargo-fuzz -f
         - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_redis -- -max_total_time=300
         - sudo chown -R travis $HOME/.cargo
     - os: linux
       rust: nightly
       env: TYPE=fuzzer_codec_thrift RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install cargo-fuzz || true)
+        - cargo install cargo-fuzz -f
         - sudo -E $HOME/.cargo/bin/cargo fuzz run -s address fuzzer_codec_thrift -- -max_total_time=300
         - sudo chown -R travis $HOME/.cargo
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ toml = "=0.2.1"
 asm = [ "tic/asm" ]
 default = []
 unstable = []
+benchcmp = []

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,82 @@
+#![cfg_attr(feature = "benchcmp", feature(test))]
+
+mod tests {
+    #[cfg(feature = "benchcmp")]
+    extern crate test;
+
+    use std::env;
+    use std::process;
+
+    #[cfg(feature = "benchcmp")]
+    #[bench]
+    fn benchcmp(_: &mut test::Bencher) {
+        let travis_pr_branch = env::var("TRAVIS_PULL_REQUEST_BRANCH");
+
+        let travis_branch = match env::var("TRAVIS_BRANCH") {
+            Ok(s) => s,
+            Err(_) => "benchcmp".to_owned(),
+        };
+
+        let travis_build_dir = match env::var("TRAVIS_BUILD_DIR") {
+            Ok(s) => s,
+            Err(_) => ".".to_owned(),
+        };
+
+        let remote_url = "https://github.com/twitter/rpc-perf";
+
+        let working_branch = match travis_pr_branch {
+            Ok(s) => s,
+            Err(_) => travis_branch,
+        };
+
+        if working_branch == "master" {
+            println!("SKIP: push to master");
+            process::exit(0);
+        }
+
+        process::Command::new("mkdir")
+            .arg("-p")
+            .arg("target")
+            .status()
+            .expect("Failed to make target dir");
+
+        let _ = process::Command::new("git")
+            .arg("clone")
+            .arg(remote_url)
+            .arg("benchcmp".to_owned())
+            .current_dir(travis_build_dir.to_owned() + "/target")
+            .output();
+
+        process::Command::new("bash")
+            .arg("-c")
+            .arg("cargo bench --features unstable | tee result.baseline")
+            .current_dir(travis_build_dir.to_owned() + "/target/benchcmp")
+            .status()
+            .expect("Failed to cargo bench baseline");
+
+        process::Command::new("bash")
+            .arg("-c")
+            .arg("cargo bench --features unstable | tee target/benchcmp/result.current")
+            .current_dir(travis_build_dir.to_owned())
+            .status()
+            .expect("Failed to cargo bench current");
+
+        let regressions = process::Command::new("cargo")
+            .arg("benchcmp")
+            .arg("target/benchcmp/result.baseline")
+            .arg("target/benchcmp/result.current")
+            .arg("--threshold")
+            .arg("20")
+            .arg("--regressions")
+            .output()
+            .expect("Failed to cargo benchcmp");
+
+        if regressions.stdout.is_empty() {
+            process::exit(0);
+        } else {
+            let output = String::from_utf8(regressions.stdout).unwrap();
+            println!("{}", output);
+            process::exit(1);
+        }
+    }
+}

--- a/src/codec/echo/gen.rs
+++ b/src/codec/echo/gen.rs
@@ -31,6 +31,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[cfg(feature = "unstable")]
+    #[allow(unused_imports)]
     use test;
 
     #[cfg(feature = "unstable")]

--- a/src/codec/memcache/gen.rs
+++ b/src/codec/memcache/gen.rs
@@ -141,6 +141,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[cfg(feature = "unstable")]
+    #[allow(unused_imports)]
     use test;
 
     #[test]

--- a/src/codec/memcache/mod.rs
+++ b/src/codec/memcache/mod.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(test))]
-
 mod gen;
 mod parse;
 

--- a/src/codec/ping/gen.rs
+++ b/src/codec/ping/gen.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(test))]
-
 pub fn ping() -> String {
     "PING\r\n".to_owned()
 }
@@ -23,6 +21,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[cfg(feature = "unstable")]
+    #[allow(unused_imports)]
     use test;
 
     #[cfg(feature = "unstable")]

--- a/src/codec/ping/mod.rs
+++ b/src/codec/ping/mod.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(test))]
-
 mod gen;
 mod parse;
 

--- a/src/codec/redis/gen.rs
+++ b/src/codec/redis/gen.rs
@@ -13,14 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(test))]
-
 mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[cfg(feature = "unstable")]
+    #[allow(unused_imports)]
     use test;
-
 
     #[test]
     fn test_flushall() {

--- a/src/codec/redis/mod.rs
+++ b/src/codec/redis/mod.rs
@@ -13,8 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#![cfg_attr(feature = "unstable", feature(test))]
-
 mod gen;
 mod parse;
 

--- a/src/codec/redis/parse.rs
+++ b/src/codec/redis/parse.rs
@@ -15,7 +15,6 @@
 
 pub use cfgtypes::ParsedResponse;
 
-
 pub fn parse_response(response: &str) -> ParsedResponse {
 
     let mut lines: Vec<&str> = response.split("\r\n").collect();


### PR DESCRIPTION
- add benches.rs to drive benchmarks across two branches
- uses cargo-benchcmp command to compare results
- fails regressions > 20%