### PR TITLE
add support for explicitly sized random data sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,26 +1,3 @@
-[root]
-name = "rpc-perf"
-version = "2.1.0-pre"
-dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "ratelimit 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "shuteye 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tic 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "adler32"
 version = "1.0.2"
@@ -431,6 +408,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "redox_syscall"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rpc-perf"
+version = "2.1.0-pre"
+dependencies = [
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-panics 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpmc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratelimit 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shuteye 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tic 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-serialize"

--- a/configs/sized_dataset.toml
+++ b/configs/sized_dataset.toml
@@ -1,0 +1,40 @@
+# this example runs a mixed key-value workload with a key/val dataset
+# sized to be exactly 500,000 6 byte keys with 64 byte values.
+#
+# num can be specified with random workloads to generate random keys
+# from a precisely sized set of potential keys.
+#
+# note that size must be sufficiently large to contain the number of
+# decimal digits in num.
+#
+# when unspecified, num will default to 0. in this case, the default
+# behavior of random workload will apply, where random ascii strings
+# that are of length size are generated.
+
+[general]
+request-timeout = 200
+connect-timeout = 500
+
+[[workload]]
+name = "get"
+method = "get"
+rate = 40000
+  [[workload.parameter]]
+  style = "random"
+  size = 6
+  num = 500000
+  regenerate = true
+
+[[workload]]
+name = "set"
+method = "set"
+rate = 10000
+  [[workload.parameter]]
+  style = "random"
+  size = 6
+  num = 500000
+  regenerate = true
+  [[workload.parameter]]
+  style = "random"
+  size = 64
+  regenerate = true

--- a/src/cfgtypes/mod.rs
+++ b/src/cfgtypes/mod.rs
@@ -90,7 +90,7 @@ pub trait Ptype: Sized {
     /// generate new state
     fn regen(&mut self);
     /// parse a `Ptype` from a toml tree
-    fn parse(seed: usize, size: usize, table: &BTreeMap<String, Value>) -> CResult<Self>;
+    fn parse(seed: usize, size: usize, num: u64, table: &BTreeMap<String, Value>) -> CResult<Self>;
 }
 
 /// `Parameter` generation style
@@ -159,12 +159,25 @@ pub fn extract_parameter<T: Ptype>(
         },
     );
 
+    let num = parameter.get("num").and_then(|k| k.as_integer()).map_or(
+        0,
+        |i| {
+            i as u64
+        },
+    );
+
+    // size is insufficient to contain num strings
+    if format!("{}", num - 1).len() > size {
+        return Err(format!("size {} insufficient to contain {} strings",
+                           size, num));
+    }
+
     let regenerate = parameter
         .get("regenerate")
         .and_then(|k| k.as_bool())
         .unwrap_or(false);
 
-    let mut value = try!(T::parse(seed, size, parameter));
+    let mut value = try!(T::parse(seed, size, num, parameter));
 
     // initialize with a random value if that is what is needed
     if style == Style::Random {

--- a/src/cfgtypes/tools.rs
+++ b/src/cfgtypes/tools.rs
@@ -16,13 +16,18 @@
 use pad::{Alignment, PadStr};
 use rand::{Rng, thread_rng};
 
-
-pub fn random_string(size: usize) -> String {
-    thread_rng().gen_ascii_chars().take(size).collect()
+pub fn random_string(size: usize, num: u64) -> String {
+    if num == 0 {
+        thread_rng().gen_ascii_chars().take(size).collect()
+    } else {
+        let k: u64 = thread_rng().gen();
+        let s = format!("{}", k % num);
+        s.pad(size, '0', Alignment::Right, true)
+    }
 }
 
 pub fn random_bytes(size: usize) -> Vec<u8> {
-    random_string(size).into_bytes()
+    random_string(size, 0).into_bytes()
 }
 
 pub fn seeded_string(size: usize, seed: usize) -> String {

--- a/src/codec/echo/mod.rs
+++ b/src/codec/echo/mod.rs
@@ -46,7 +46,7 @@ impl Ptype for EchoData {
         self.bytes = tools::random_bytes(self.size);
     }
 
-    fn parse(seed: usize, size: usize, _: &BTreeMap<String, Value>) -> CResult<Self> {
+    fn parse(seed: usize, size: usize, _: u64, _: &BTreeMap<String, Value>) -> CResult<Self> {
         let bts = (seed..(seed + size)).map(|i| i as u8).collect();
         Ok(EchoData {
             size: size,

--- a/src/codec/memcache/mod.rs
+++ b/src/codec/memcache/mod.rs
@@ -53,17 +53,19 @@ pub struct MemcacheParser;
 #[derive(Clone, Debug)]
 struct CacheData {
     size: usize,
+    num: u64,
     string: String,
 }
 
 impl Ptype for CacheData {
     fn regen(&mut self) {
-        self.string = tools::random_string(self.size);
+        self.string = tools::random_string(self.size, self.num);
     }
 
-    fn parse(seed: usize, size: usize, _: &BTreeMap<String, Value>) -> CResult<Self> {
+    fn parse(seed: usize, size: usize, num: u64, _: &BTreeMap<String, Value>) -> CResult<Self> {
         Ok(CacheData {
             size: size,
+            num: num,
             string: tools::seeded_string(size, seed),
         })
     }

--- a/src/codec/redis_inline/mod.rs
+++ b/src/codec/redis_inline/mod.rs
@@ -31,17 +31,19 @@ type Param = Parameter<RedisData>;
 #[derive(Clone, Debug)]
 struct RedisData {
     size: usize,
+    num: u64,
     string: String,
 }
 
 impl Ptype for RedisData {
     fn regen(&mut self) {
-        self.string = tools::random_string(self.size);
+        self.string = tools::random_string(self.size, self.num);
     }
 
-    fn parse(seed: usize, size: usize, _: &BTreeMap<String, Value>) -> CResult<Self> {
+    fn parse(seed: usize, size: usize, num: u64, _: &BTreeMap<String, Value>) -> CResult<Self> {
         Ok(RedisData {
             size: size,
+            num: num,
             string: tools::seeded_string(size, seed),
         })
     }

--- a/src/codec/redis_resp/mod.rs
+++ b/src/codec/redis_resp/mod.rs
@@ -31,17 +31,19 @@ type Param = Parameter<RedisData>;
 #[derive(Clone, Debug)]
 struct RedisData {
     size: usize,
+    num: u64,
     string: String,
 }
 
 impl Ptype for RedisData {
     fn regen(&mut self) {
-        self.string = tools::random_string(self.size);
+        self.string = tools::random_string(self.size, self.num);
     }
 
-    fn parse(seed: usize, size: usize, _: &BTreeMap<String, Value>) -> CResult<Self> {
+    fn parse(seed: usize, size: usize, num: u64, _: &BTreeMap<String, Value>) -> CResult<Self> {
         Ok(RedisData {
             size: size,
+            num: num,
             string: tools::seeded_string(size, seed),
         })
     }

--- a/src/codec/thrift/config.rs
+++ b/src/codec/thrift/config.rs
@@ -147,6 +147,11 @@ fn extract_parameter(i: usize, parameter: &BTreeMap<String, Value>) -> CResult<P
         None => 1,
     };
 
+    let num = match parameter.get("num").and_then(|k| k.as_integer()) {
+        Some(s) => s as u64,
+        None => 0,
+    };
+
     let regenerate = match parameter.get("regenerate").and_then(|k| k.as_bool()) {
         Some(s) => s,
         None => false,
@@ -180,13 +185,14 @@ fn extract_parameter(i: usize, parameter: &BTreeMap<String, Value>) -> CResult<P
     };
 
     if style == Style::Random {
-        value.regen(size);
+        value.regen(size, num);
     }
 
     Ok(Parameter {
         id: id,
         seed: seed,
         size: size,
+        num: num,
         style: style,
         regenerate: regenerate,
         value: value,

--- a/src/codec/thrift/mod.rs
+++ b/src/codec/thrift/mod.rs
@@ -30,6 +30,7 @@ pub struct Parameter {
     pub id: Option<i16>,
     pub seed: usize,
     pub size: usize,
+    pub num: u64,
     pub style: Style,
     pub regenerate: bool,
     pub value: Tvalue,
@@ -38,7 +39,7 @@ pub struct Parameter {
 impl Parameter {
     pub fn regen(&mut self) {
         if self.regenerate && self.style == Style::Random {
-            self.value.regen(self.size)
+            self.value.regen(self.size, self.num)
         }
     }
 }
@@ -61,7 +62,7 @@ pub enum Tvalue {
 }
 
 impl Tvalue {
-    fn regen(&mut self, size: usize) {
+    fn regen(&mut self, size: usize, num: u64) {
         match *self {
             Tvalue::Bool(ref mut v) => *v = random::<bool>(),
             Tvalue::Byte(ref mut v) => *v = random::<u8>(),
@@ -69,7 +70,7 @@ impl Tvalue {
             Tvalue::Int16(ref mut v) => *v = random::<i16>(),
             Tvalue::Int32(ref mut v) => *v = random::<i32>(),
             Tvalue::Int64(ref mut v) => *v = random::<i64>(),
-            Tvalue::String(ref mut v) => *v = tools::random_string(size),
+            Tvalue::String(ref mut v) => *v = tools::random_string(size, num),
             _ => {}
         }
     }

--- a/src/codec/thrift/testutil.rs
+++ b/src/codec/thrift/testutil.rs
@@ -25,6 +25,7 @@ pub fn mk_param(id: i16, value: Tvalue) -> Parameter {
         id: Some(id),
         seed: 0,
         size: 1,
+        num: 0,
         style: Style::Static,
         regenerate: false,
         value: value,


### PR DESCRIPTION
This change adds support for randomly generated strings to be from a dataset of size n. For this to happen, random workloads will take an additional `num` parameter which specifies the data set size. For example, with `num == 1_000_000`, the random workload will generate strings from a set of 1,000,000 strings. This will be useful for performance testing caches at different levels of heap utilization. 

I didn't find any documentation on how to configure workloads, so I added the details in an example configuration. Please let me know if there is a better place for this. I am a beginner at rust, so please let me know if anything I am writing is non idiomatic/incorrect. 