### PR TITLE
config: allow specifying endpoints in toml

### DIFF
--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/twitter/rpc-perf"
 publish = false
 
 [dependencies]
-bytes = "=0.4.11"
+bytes = "0.4.11"
 crc = "1.8.1"
 datastructures = { path = "../datastructures" }
 rand = "0.6.4"

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 
 [dependencies]
 logger = { path = "../logger" }
-parking_lot = "*"
-time = "*"
+parking_lot = "0.7.1"
+time = "0.1.42"

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -11,4 +11,4 @@ publish = false
 
 [dependencies]
 log = { version = "0.4.6", features = ["std"] }
-time = "0.1.40"
+time = "0.1.42"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/twitter/rpc-perf"
 publish = false
 
 [dependencies]
-evmap = "*"
+evmap = "4.1.1"
 datastructures = { path = "../datastructures" }
 logger = { path = "../logger" }
-time = "0.1.41"
+time = "0.1.42"

--- a/ratelimiter/Cargo.toml
+++ b/ratelimiter/Cargo.toml
@@ -11,4 +11,4 @@ publish = false
 
 [dependencies]
 datastructures = { path = "../datastructures" }
-time = "*"
+time = "0.1.42"

--- a/rpc-perf/configs/default.toml
+++ b/rpc-perf/configs/default.toml
@@ -5,8 +5,8 @@ windows = 5 # run for 5 intervals
 clients = 1 # use a single client thread
 poolsize = 1 # each client has 1 connection per endpoint
 tcp_nodelay = false # do not enable tcp_nodelay
-request_timeout = 200 # milliseconds
-connect_timeout = 200 # milliseconds
+request_timeout = 200_000 # microseconds
+connect_timeout = 200_000 # microseconds
 
 [[keyspace]]
 length = 8 # 8 byte keys

--- a/rpc-perf/src/config/mod.rs
+++ b/rpc-perf/src/config/mod.rs
@@ -279,7 +279,6 @@ impl Config {
                     .long("endpoint")
                     .value_name("HOST:PORT or IP:PORT")
                     .help("Provide a server endpoint to test")
-                    .required(true)
                     .multiple(true)
                     .takes_value(true),
             )
@@ -434,21 +433,23 @@ impl Config {
             config.general.set_warmup_hitrate(Some(warmup_hitrate));
         }
 
-        let mut endpoints = Vec::new();
+        if matches.is_present("endpoint") {
+            let mut endpoints = Vec::new();
 
-        for endpoint in matches.values_of("endpoint").unwrap() {
-            let mut addrs = endpoint.to_socket_addrs().unwrap_or_else(|_| {
-                println!("ERROR: endpoint address is malformed: {}", endpoint);
-                std::process::exit(1);
-            });
-            addrs.next().unwrap_or_else(|| {
-                println!("ERROR: failed to resolve address: {}", endpoint);
-                std::process::exit(1);
-            });
-            endpoints.push(endpoint.to_string());
+            for endpoint in matches.values_of("endpoint").unwrap() {
+                let mut addrs = endpoint.to_socket_addrs().unwrap_or_else(|_| {
+                    println!("ERROR: endpoint address is malformed: {}", endpoint);
+                    std::process::exit(1);
+                });
+                addrs.next().unwrap_or_else(|| {
+                    println!("ERROR: failed to resolve address: {}", endpoint);
+                    std::process::exit(1);
+                });
+                endpoints.push(endpoint.to_string());
+            }
+
+            config.general.set_endpoints(Some(endpoints));
         }
-
-        config.general.set_endpoints(Some(endpoints));
 
         config
             .general

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -118,7 +118,7 @@ impl<'a> StandardOut<'a> {
             delta_count(&self.previous, &current, Stat::ConnectionsError).unwrap_or(0),
             delta_count(&self.previous, &current, Stat::ConnectionsTimeout).unwrap_or(0),
             self.recorder.counter(Stat::ConnectionsOpened)
-                - self.recorder.counter(Stat::ConnectionsClosed),
+                .saturating_sub(self.recorder.counter(Stat::ConnectionsClosed)),
         );
 
         info!(


### PR DESCRIPTION
* change argument parsing to make `--endpoint` optional on command line
* allow CLI to override config file for endpoints
* fix a wrap-around issue with counting open connections
* default config incorrectly specifies timeouts as ms when the unit is us