### PR TITLE
Add support for mget, mset, and more!

### DIFF
--- a/rpc-perf/configs/default.toml
+++ b/rpc-perf/configs/default.toml
@@ -13,8 +13,8 @@ length = 8 # 8 byte keys
 count = 10_000_000 # limit to 10M keys
 weight = 1 # this keyspace has a weight of 1
 commands = [ # get:set ratio is 1:1
-    {action = "get", weight = 1},
-    {action = "set", weight = 1},
+    {weight = 1, action = {type = "get"}},
+    {weight = 1, action = {type = "set"}},
 ]
 values = [ # value length will always be 64 bytes
     {length = 64, weight = 1},

--- a/rpc-perf/configs/redis.toml
+++ b/rpc-perf/configs/redis.toml
@@ -1,6 +1,6 @@
 [general]
-protocol = "memcache"
-interval = 60 # seconds
+protocol = "redisresp"
+interval = 5 # seconds
 windows = 5 # run for 5 intervals
 clients = 1 # use a single client thread
 poolsize = 1 # each client has 1 connection per endpoint
@@ -12,10 +12,9 @@ connect_ratelimit = 1000 # 1K connects/second
 warmup_hitrate = 0.9 # do warmup until 90% hitrate is achieved
 waterfall = "waterfall.png" # produce a waterfall at end of run
 endpoints = [ # specify the endpoints in the config
-    "127.0.0.1:11211",
+    "127.0.0.1:6379",
 ]
 
-# this keyspace will get
 [[keyspace]]
 length = 8 # 8 byte keys
 count = 10_000 # limit to 10K keys
@@ -23,21 +22,11 @@ weight = 9 # this keyspace will be used for 90% of requests
 commands = [ # get:set ratio is 4:1 - read heavy
     {weight = 4, action = {type = "get"}},
     {weight = 1, action = {type = "set"}},
+    {weight = 1, action = {type = "mget", key_count = 2}},
+    {weight = 1, action = {type = "mset", key_count = 2}},
 ]
 values = [ # uses multiple value lengths with different weights
     {length = 64, weight = 8}, # 80% as 64 byte values
     {length = 128, weight = 1}, # 10% as 128 byte values
     {length = 256, weight = 1}, # 10% as 256 byte values
-]
-
-[[keyspace]]
-length = 32 # 32 byte keys
-count = 1_000 # limit to 1K keys
-weight = 1 # this keyspace will be used for 10% of requests
-commands = [ # get:set ratio is 1:4 - write heavy
-    {weight = 1, action = {type = "get"}},
-    {weight = 4, action = {type = "set"}},
-]
-values = [
-    {length = 64, weight = 1}, # 100% as 64 byte values
 ]

--- a/rpc-perf/configs/tls.toml
+++ b/rpc-perf/configs/tls.toml
@@ -16,8 +16,8 @@ length = 8 # 8 byte keys
 count = 10_000_000 # limit to 10M keys
 weight = 1 # this keyspace has a weight of 1
 commands = [ # get:set ratio is 1:1
-    {action = "get", weight = 1},
-    {action = "set", weight = 1},
+    {weight = 1, action= {type = "get"}},
+    {weight = 1, action= {type = "set"}},
 ]
 values = [ # value length will always be 64 bytes
     {length = 64, weight = 1},

--- a/rpc-perf/src/codec/echo.rs
+++ b/rpc-perf/src/codec/echo.rs
@@ -51,6 +51,9 @@ impl Codec for Echo {
 
     fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng) {
         let command = self.generate(rng);
-        self.codec.echo(buf, command.key().unwrap());
+        match command {
+            Command::Get(key) => self.codec.echo(buf, key.as_bytes()),
+            _ => unreachable!(),
+        }
     }
 }

--- a/rpc-perf/src/codec/mod.rs
+++ b/rpc-perf/src/codec/mod.rs
@@ -17,6 +17,7 @@ use crate::config::Generator;
 use crate::stats::Simple;
 use bytes::BytesMut;
 use rand::rngs::ThreadRng;
+use std::collections::HashMap;
 
 mod echo;
 mod memcache;
@@ -31,47 +32,28 @@ pub use codec::Decoder;
 pub use codec::Error;
 pub use codec::Response;
 
-use crate::config::Action;
-
-pub struct Command {
-    action: Action,
-    key: Option<String>,
-    value: Option<String>,
+pub enum Command {
+    Get(String),
+    Set(String, String),
+    Mget(Vec<String>),
+    Mset(HashMap<String, String>),
 }
 
 impl Command {
     pub fn get(key: String) -> Command {
-        Command {
-            action: Action::Get,
-            key: Some(key),
-            value: None,
-        }
+        Command::Get(key)
     }
 
     pub fn set(key: String, value: String) -> Command {
-        Command {
-            action: Action::Set,
-            key: Some(key),
-            value: Some(value),
-        }
+        Command::Set(key, value)
     }
 
-    pub fn action(&self) -> Action {
-        self.action
+    pub fn mget(keys: Vec<String>) -> Command {
+        Command::Mget(keys)
     }
 
-    pub fn key(&self) -> Option<&[u8]> {
-        match &self.key {
-            Some(key) => Some(key.as_bytes()),
-            None => None,
-        }
-    }
-
-    pub fn value(&self) -> Option<&[u8]> {
-        match &self.value {
-            Some(value) => Some(value.as_bytes()),
-            None => None,
-        }
+    pub fn mset(kvs: HashMap<String, String>) -> Command {
+        Command::Mset(kvs)
     }
 }
 


### PR DESCRIPTION
Hello, I was looking at testing more complex commands for redis such as mget, mset, eval, evalsha which were supported in the previous version, but not in the recent rewrite. I've tried to prototype how I think it could be possible to support commands that have additional options such as the number of keys, a script, script arguments, and so on. 

I've prototyped for mget and mset, and was wondering if my approach was correct here 😄 If so, I'll continue to add more commands since we are looking at heavily benchmarking different workloads for redis.

Thanks!