### PR TITLE
bugfix for histograms and metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cdatastructures"
 version = "0.1.0"
 dependencies = [
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -157,9 +157,9 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "logger 0.1.0",
- "metrics 0.1.0",
+ "metrics 0.1.1",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "datastructures"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "logger 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,9 +436,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "metrics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "evmap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -682,7 +682,7 @@ dependencies = [
 name = "ratelimiter"
 version = "0.1.0"
 dependencies = [
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -749,10 +749,10 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codec 0.1.0",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
- "metrics 0.1.0",
+ "metrics 0.1.1",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1049,7 +1049,7 @@ dependencies = [
 name = "waterfall"
 version = "0.1.1"
 dependencies = [
- "datastructures 0.1.1",
+ "datastructures 0.1.2",
  "dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datastructures"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/datastructures/src/histogram/latched.rs
+++ b/datastructures/src/histogram/latched.rs
@@ -112,17 +112,8 @@ impl Latched {
             let max = if index == self.buckets.len() - 1 {
                 self.max()
             } else {
-                self.get_value(index).unwrap()
+                self.get_value(index).unwrap() + 1
             };
-            if min == max {
-                println!(
-                    "bucket: {} for value: {} has min: {} and max: {}",
-                    index,
-                    self.get_value(index).unwrap(),
-                    min,
-                    max
-                );
-            }
             let bucket = Bucket::new(min, max);
             bucket.incr(count);
             Some(bucket)
@@ -222,7 +213,11 @@ impl Histogram for Latched {
         if samples == 0 {
             return None;
         }
-        let need = (samples as f64 * percentile).ceil() as usize;
+        let need = if percentile == 0.0 {
+            1
+        } else {
+            (samples as f64 * percentile).ceil() as usize
+        };
         let mut have = self.too_low();
         if have >= need {
             return Some(self.min());
@@ -523,6 +518,7 @@ mod tests {
             histogram.incr(i, 1);
         }
 
+        assert_eq!(histogram.percentile(0.0).unwrap(), 1);
         assert_eq!(histogram.percentile(0.01).unwrap(), 1);
         assert_eq!(histogram.percentile(0.25).unwrap(), 25);
         assert_eq!(histogram.percentile(0.5).unwrap(), 50);

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
* addresses histogram bug where percentile 0.0 always is 0
* addresses histogram bug where bucket width is under-reported
* addresses metrics bug where wrap-around may be improperly handled