### PR TITLE
bugfix: fixes histogram range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cdatastructures"
 version = "0.1.0"
 dependencies = [
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -157,7 +157,7 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "logger 0.1.0",
  "metrics 0.1.1",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "datastructures"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "logger 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "metrics"
 version = "0.1.1"
 dependencies = [
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "evmap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -682,7 +682,7 @@ dependencies = [
 name = "ratelimiter"
 version = "0.1.0"
 dependencies = [
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -749,7 +749,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codec 0.1.0",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "metrics 0.1.1",
@@ -1049,7 +1049,7 @@ dependencies = [
 name = "waterfall"
 version = "0.1.1"
 dependencies = [
- "datastructures 0.1.2",
+ "datastructures 0.1.3",
  "dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datastructures"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/datastructures/src/histogram/latched.rs
+++ b/datastructures/src/histogram/latched.rs
@@ -197,9 +197,6 @@ impl Histogram for Latched {
         } else if let Ok(index) = self.get_index(value) {
             if let Some(bucket) = self.buckets.get(index) {
                 bucket.incr(count);
-            } else {
-                println!("this is unexpected");
-                self.too_high.incr(count);
             }
         } else {
             self.too_high.incr(count);

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -183,17 +183,26 @@ mod tests {
         assert_eq!(recorder.percentile("test".to_string(), 0.0), None);
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 1_000_000_000, value: 1 },
+            Measurement::Counter {
+                time: 1_000_000_000,
+                value: 1,
+            },
         );
         assert_eq!(recorder.counter("test".to_string()), 1);
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 2_000_000_000, value: 1 },
+            Measurement::Counter {
+                time: 2_000_000_000,
+                value: 1,
+            },
         );
         assert_eq!(recorder.counter("test".to_string()), 1);
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 3_000_000_000, value: 2 },
+            Measurement::Counter {
+                time: 3_000_000_000,
+                value: 2,
+            },
         );
         assert_eq!(recorder.counter("test".to_string()), 2);
         assert!(approx_eq(
@@ -222,11 +231,17 @@ mod tests {
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 0_usize.wrapping_sub(2_000_000_000), value: 0 },
+            Measurement::Counter {
+                time: 0_usize.wrapping_sub(2_000_000_000),
+                value: 0,
+            },
         );
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 0_usize.wrapping_sub(1_000_000_000), value: 1 },
+            Measurement::Counter {
+                time: 0_usize.wrapping_sub(1_000_000_000),
+                value: 1,
+            },
         );
         assert_eq!(recorder.counter("test".to_string()), 1);
         recorder.record(
@@ -234,18 +249,32 @@ mod tests {
             Measurement::Counter { time: 0, value: 2 },
         );
         assert_eq!(recorder.counter("test".to_string()), 2);
-        assert!(approx_eq(recorder.percentile("test".to_string(), 0.0).unwrap(), 1, 3));
+        assert!(approx_eq(
+            recorder.percentile("test".to_string(), 0.0).unwrap(),
+            1,
+            3
+        ));
         recorder.clear();
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 0, value: 0_usize.wrapping_sub(1) },
+            Measurement::Counter {
+                time: 0,
+                value: 0_usize.wrapping_sub(1),
+            },
         );
         recorder.record(
             "test".to_string(),
-            Measurement::Counter { time: 1_000_000_000, value: 0 },
+            Measurement::Counter {
+                time: 1_000_000_000,
+                value: 0,
+            },
         );
-        assert!(approx_eq(recorder.percentile("test".to_string(), 0.0).unwrap(), 1, 3));
+        assert!(approx_eq(
+            recorder.percentile("test".to_string(), 0.0).unwrap(),
+            1,
+            3
+        ));
     }
 
     #[test]
@@ -288,10 +317,7 @@ mod tests {
         ];
         for (time, &value) in data.iter().enumerate() {
             let time = time * 1_000_000_000;
-            recorder.record(
-                "test".to_string(),
-                Measurement::Counter { time, value },
-            );
+            recorder.record("test".to_string(), Measurement::Counter { time, value });
             assert_eq!(recorder.counter("test".to_string()), value);
         }
         assert!(approx_eq(


### PR DESCRIPTION
This change fixes the histogram to cover the full range requested.
Previously, it may have truncated the range, resulting in incorrect
data for upper percentiles when nearly the full range of the histogram
was in-use.

Fixes existing tests and adds a new test to verify the correct behavior.