### PR TITLE
datastructures: histogram improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
  "timer 0.1.1",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "waterfall 0.2.0",
+ "waterfall 0.2.1",
  "webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "waterfall"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "datastructures 0.2.1",
  "dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cdatastructures"
 version = "0.2.0"
 dependencies = [
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -157,7 +157,7 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "logger 0.1.0",
  "metrics 0.2.0",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "datastructures"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "logger 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "metrics"
 version = "0.2.0"
 dependencies = [
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "evmap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -682,7 +682,7 @@ dependencies = [
 name = "ratelimiter"
 version = "0.2.0"
 dependencies = [
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -749,7 +749,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codec 0.1.0",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "metrics 0.2.0",
@@ -1049,7 +1049,7 @@ dependencies = [
 name = "waterfall"
 version = "0.2.0"
 dependencies = [
- "datastructures 0.2.0",
+ "datastructures 0.2.1",
  "dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datastructures"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 

--- a/datastructures/ffi/cdatastructures/src/histogram.rs
+++ b/datastructures/ffi/cdatastructures/src/histogram.rs
@@ -12,13 +12,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use datastructures::{Histogram, HistogramBuilder};
+use datastructures::{Histogram, LatchedHistogram};
 use libc::{c_float, uint64_t, uintptr_t};
 
 /// Create a new `histogram`
 #[no_mangle]
 pub extern "C" fn histogram_new(max: uint64_t, precision: uintptr_t) -> *mut Histogram<u64> {
-    Box::into_raw(HistogramBuilder::new(max, precision, None).build())
+    Box::into_raw(Box::new(LatchedHistogram::new(max, precision)))
 }
 
 /// Clear the count stored in the `histogram`

--- a/datastructures/src/histogram/circular.rs
+++ b/datastructures/src/histogram/circular.rs
@@ -1,0 +1,345 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::bool::Bool;
+use crate::counter::Counter;
+use crate::counter::Counting;
+use std::convert::From;
+
+use crate::histogram::bucket::Bucket;
+use crate::histogram::latched::Iter;
+use crate::histogram::latched::Latched;
+use crate::histogram::Histogram;
+
+#[derive(Clone)]
+/// A thread-safe fixed-size `Histogram` which allows multiple writers and
+/// retains up to N samples across a given `Duration`
+pub struct Circular<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    data: Latched<C>,
+    samples: Vec<Sample<C>>,
+    oldest: Counter<u32>,
+    newest: Counter<u32>,
+    used: Counter<u32>,
+    window: Counter<u64>,
+}
+
+#[derive(Clone)]
+struct Sample<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    value: Counter<u64>,
+    count: Counter<C>,
+    time: Counter<u64>,
+    decrement: Bool,
+}
+
+impl<C> Default for Sample<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    fn default() -> Sample<C> {
+        Sample {
+            value: Default::default(),
+            count: Default::default(),
+            time: Default::default(),
+            decrement: Bool::new(false),
+        }
+    }
+}
+
+impl<'a, C> IntoIterator for &'a Circular<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    type Item = Bucket<C>;
+    type IntoIter = Iter<'a, C>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<C> Circular<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    /// Create a new `MovingHistogram` with the given max, precision, window, and capacity
+    pub fn new(max: u64, precision: usize, window: u64, capacity: u32) -> Self {
+        let mut samples = Vec::with_capacity(capacity as usize);
+        for _ in 0..capacity {
+            samples.push(Sample::default());
+        }
+        Self {
+            data: Latched::<C>::new(max, precision),
+            samples,
+            newest: Default::default(),
+            oldest: Default::default(),
+            used: Default::default(),
+            window: Counter::new(window),
+        }
+    }
+
+    // internal function to expire old samples
+    fn trim(&self, time: u64) {
+        let expired = time - self.window.get();
+        if self.used.get() == 0 {
+            return;
+        }
+        let oldest = self.oldest.get() as usize;
+        let newest = self.newest.get() as usize;
+        if oldest < newest {
+            for i in oldest..newest {
+                if self.samples[i].time.get() < expired {
+                    self.data
+                        .decrement(self.samples[i].value.get(), self.samples[i].count.get());
+                    self.oldest.increment(1);
+                    if self.oldest.get() as usize >= self.samples.len() {
+                        self.oldest.set(0);
+                    }
+                    self.used.decrement(1);
+                } else {
+                    return;
+                }
+            }
+        } else {
+            for i in oldest..self.samples.len() {
+                if self.samples[i].time.get() < expired {
+                    self.data
+                        .decrement(self.samples[i].value.get(), self.samples[i].count.get());
+                    self.oldest.increment(1);
+                    if self.oldest.get() as usize >= self.samples.len() {
+                        self.oldest.set(0);
+                    }
+                    self.used.decrement(1);
+                } else {
+                    return;
+                }
+            }
+            for i in 0..newest {
+                if self.samples[i].time.get() < expired {
+                    self.data
+                        .decrement(self.samples[i].value.get(), self.samples[i].count.get());
+                    self.oldest.increment(1);
+                    if self.oldest.get() as usize >= self.samples.len() {
+                        self.oldest.set(0);
+                    }
+                    self.used.decrement(1);
+                } else {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+impl<C> Histogram<C> for Circular<C>
+where
+    C: Counting,
+    u64: From<C>,
+{
+    /// Remove all samples from the datastructure
+    fn reset(&self) {
+        self.data.reset();
+        self.used.reset();
+        self.oldest.reset();
+        self.newest.reset();
+    }
+
+    /// Get total count of entries
+    fn samples(&self) -> u64 {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.samples()
+    }
+
+    /// Decrement the bucket that represents value by count
+    fn decrement(&self, value: u64, count: C) {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.decrement(value, count);
+        if self.used.get() as usize == self.samples.len() {
+            let oldest = self.oldest.get() as usize;
+            if self.samples[oldest].decrement.get() {
+                self.data.increment(
+                    self.samples[oldest].value.get(),
+                    self.samples[oldest].count.get(),
+                );
+            } else {
+                self.data.decrement(
+                    self.samples[oldest].value.get(),
+                    self.samples[oldest].count.get(),
+                );
+            }
+            self.oldest.increment(1);
+            if self.oldest.get() as usize >= self.samples.len() {
+                self.oldest.set(0);
+            }
+            self.used.decrement(1);
+        }
+        let newest = self.newest.get() as usize;
+        if newest >= self.samples.len() - 1 {
+            self.newest.set(0);
+            self.samples[0].count.set(count);
+            self.samples[0].value.set(value);
+            self.samples[0].time.set(time);
+            self.samples[0].decrement.set(true);
+        } else {
+            self.newest.increment(1);
+            self.samples[newest].count.set(count);
+            self.samples[newest].value.set(value);
+            self.samples[newest].time.set(time);
+            self.samples[newest].decrement.set(true);
+        }
+        self.used.increment(1);
+    }
+
+    /// Increment the bucket that represents value by count
+    fn increment(&self, value: u64, count: C) {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.increment(value, count);
+        if self.used.get() as usize == self.samples.len() {
+            let oldest = self.oldest.get() as usize;
+            if self.samples[oldest].decrement.get() {
+                self.data.increment(
+                    self.samples[oldest].value.get(),
+                    self.samples[oldest].count.get(),
+                );
+            } else {
+                self.data.decrement(
+                    self.samples[oldest].value.get(),
+                    self.samples[oldest].count.get(),
+                );
+            }
+            self.oldest.increment(1);
+            if self.oldest.get() as usize >= self.samples.len() {
+                self.oldest.set(0);
+            }
+            self.used.decrement(1);
+        }
+        let newest = self.newest.get() as usize;
+        if newest >= self.samples.len() - 1 {
+            self.newest.set(0);
+            self.samples[0].count.set(count);
+            self.samples[0].value.set(value);
+            self.samples[0].time.set(time);
+            self.samples[0].decrement.set(false);
+        } else {
+            self.newest.increment(1);
+            self.samples[newest].count.set(count);
+            self.samples[newest].value.set(value);
+            self.samples[newest].time.set(time);
+            self.samples[newest].decrement.set(false);
+        }
+        self.used.increment(1);
+    }
+
+    /// Return the value for the given percentile (0.0 - 1.0)
+    fn percentile(&self, percentile: f64) -> Option<u64> {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.percentile(percentile)
+    }
+
+    fn count(&self, value: u64) -> u64 {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.count(value)
+    }
+
+    fn too_high(&self) -> u64 {
+        let time = time::precise_time_ns();
+        self.trim(time);
+        self.data.too_high()
+    }
+
+    fn max(&self) -> u64 {
+        self.data.max()
+    }
+
+    fn precision(&self) -> usize {
+        self.data.precision()
+    }
+
+    fn sum(&self) -> Option<u64> {
+        self.data.sum()
+    }
+
+    fn mean(&self) -> Option<f64> {
+        self.data.mean()
+    }
+
+    fn std_dev(&self) -> Option<f64> {
+        self.data.std_dev()
+    }
+
+    fn mode(&self) -> Option<u64> {
+        self.data.mode()
+    }
+
+    fn highest_count(&self) -> Option<u64> {
+        self.data.highest_count()
+    }
+
+    fn buckets(&self) -> usize {
+        self.data.buckets()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{thread, time};
+
+    #[test]
+    fn empty() {
+        let h = Circular::<u64>::new(10, 3, 2_000_000_000, 1000);
+        assert_eq!(h.samples(), 0);
+    }
+
+    #[test]
+    fn rolloff() {
+        let h = Circular::<u64>::new(10, 3, 2_000_000_000, 1000);
+        assert_eq!(h.samples(), 0);
+        h.increment(1, 1);
+        assert_eq!(h.samples(), 1);
+        thread::sleep(time::Duration::new(1, 0));
+        assert_eq!(h.samples(), 1);
+        thread::sleep(time::Duration::new(2, 0));
+        assert_eq!(h.samples(), 0);
+    }
+
+    #[test]
+    fn threaded_access() {
+        let histogram = Circular::<u64>::new(10, 3, 10_000_000_000, 2000000);
+
+        let mut threads = Vec::new();
+
+        for _ in 0..2 {
+            let histogram = histogram.clone();
+            threads.push(thread::spawn(move || {
+                for i in 0..100_000 {
+                    histogram.increment(i, 1);
+                }
+            }));
+        }
+
+        for thread in threads {
+            thread.join().expect("Failed to join child thread");
+        }
+        thread::sleep(time::Duration::new(5, 0));
+        assert_eq!(histogram.samples(), 200_000);
+        thread::sleep(time::Duration::new(6, 0));
+        assert_eq!(histogram.samples(), 0);
+    }
+}

--- a/datastructures/src/histogram/latched.rs
+++ b/datastructures/src/histogram/latched.rs
@@ -232,7 +232,7 @@ where
         let mut have = 0;
         for (outer_index, outer_counter) in self.outer_buckets.iter().enumerate() {
             if have + outer_counter.get() >= need {
-                for index in (outer_index*1000)..((outer_index + 1)*1000) {
+                for index in (outer_index * 1000)..((outer_index + 1) * 1000) {
                     have += u64::from(self.buckets[index].get());
                     if have >= need {
                         return Some(self.get_value(index).unwrap());

--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -13,5 +13,5 @@ pub use crate::counter::*;
 pub use crate::heatmap::Builder as HeatmapBuilder;
 pub use crate::heatmap::Heatmap;
 pub use crate::histogram::Builder as HistogramBuilder;
-pub use crate::histogram::{Histogram, LatchedHistogram, MovingHistogram};
+pub use crate::histogram::{CircularHistogram, Histogram, LatchedHistogram, MovingHistogram};
 pub use crate::wrapper::*;

--- a/metrics/examples/benchmarks.rs
+++ b/metrics/examples/benchmarks.rs
@@ -117,7 +117,7 @@ pub fn sized_run(
         } else {
             "test".to_string()
         };
-        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None);
+        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
         recorder.add_channel(label.clone(), source, Some(histogram_config));
         thread_pool.push(thread::spawn(move || {
             for value in 0..(max / threads) {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -177,7 +177,7 @@ mod tests {
     fn counter_channel() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None);
+        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
         recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         assert_eq!(recorder.percentile("test".to_string(), 0.0), None);
@@ -226,7 +226,7 @@ mod tests {
     fn counter_wraparound() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None);
+        let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
         recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
@@ -281,7 +281,7 @@ mod tests {
     fn counter_data() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(80_000_000_000, 3, None);
+        let histogram_config = HistogramBuilder::new(80_000_000_000, 3, None, None);
         recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         let data: Vec<u64> = vec![
@@ -336,7 +336,7 @@ mod tests {
     fn distribution_channel() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(100, 3, None);
+        let histogram_config = HistogramBuilder::new(100, 3, None, None);
         recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
@@ -372,7 +372,7 @@ mod tests {
     fn gauge_channel() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(100, 3, None);
+        let histogram_config = HistogramBuilder::new(100, 3, None, None);
         recorder.add_channel(name.clone(), Source::Gauge, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record("test".to_string(), Measurement::Gauge { value: 0, time: 1 });
@@ -398,7 +398,7 @@ mod tests {
     fn time_interval_channel() {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
-        let histogram_config = HistogramBuilder::new(100, 3, None);
+        let histogram_config = HistogramBuilder::new(100, 3, None, None);
         recorder.add_channel(name.clone(), Source::TimeInterval, Some(histogram_config));
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -332,7 +332,7 @@ impl Simple {
     }
 
     pub fn add_histogram_channel<T: ToString>(&self, label: T, max: u64, precision: usize) {
-        let histogram_config = HistogramBuilder::new(max, precision, None);
+        let histogram_config = HistogramBuilder::new(max, precision, None, None);
         self.inner.add_channel(
             label.to_string(),
             Source::TimeInterval,
@@ -354,7 +354,7 @@ impl Simple {
     }
 
     pub fn add_distribution_channel<T: ToString>(&self, label: T, max: u64, precision: usize) {
-        let histogram_config = HistogramBuilder::new(max, precision, None);
+        let histogram_config = HistogramBuilder::new(max, precision, None, None);
         self.inner.add_channel(
             label.to_string(),
             Source::Distribution,

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterfall"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -28,7 +28,7 @@ fn main() {
 
     info!("Welcome to the simulator!");
 
-    let histogram = HistogramBuilder::<u64>::new(1_000_000, 2, None).build();
+    let histogram = HistogramBuilder::<u64>::new(1_000_000, 2, None, None).build();
     let heatmap = Heatmap::<u64>::new(1_000_000, 2, 1_000_000, 5_000_000_000);
 
     let distribution = Normal::new(500.0, 250.0);

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 
 use datastructures::Counting;
-use datastructures::{Heatmap, HistogramBuilder};
+use datastructures::{Heatmap, Histogram, LatchedHistogram};
 use hsl::HSL;
 use logger::*;
 use png::HasParameters;
@@ -40,7 +40,7 @@ pub fn save_waterfall<S: ::std::hash::BuildHasher, C: 'static>(
     // create image buffer
     let mut buffer = ImageBuffer::<ColorRgb>::new(width, height);
 
-    let histogram = HistogramBuilder::new(heatmap.highest_count(), 3, None).build();
+    let histogram = LatchedHistogram::new(heatmap.highest_count(), 3);
     for slice in heatmap {
         for b in slice.histogram().into_iter() {
             if b.weighted_count() > 0 {


### PR DESCRIPTION
Improves the performance of the percentile operations for the
histogram datastructures by using slightly more memory to maintain
a secondary set of counts that cover wider ranges. This is used to
accelerate the totals() and percentile() functions.

Adds a new `CircularHistogram` which is like `MovingHistogram`
but uses a fixed-size circular buffer to store the sample history. It
can be beneficial to use it when you know how many samples you
wish to retain across the time window. It has faster performance
than `MovingHistogram`.