### PR TITLE
timer: add next_timeout()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
  "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "timer 0.1.1",
+ "timer 0.1.2",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.2.1",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "timer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "logger 0.1.0",
 ]

--- a/timer/Cargo.toml
+++ b/timer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timer"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Adds a function to the timer to return an option representing the
next timeout if there is one. This can be useful to get the deadline
for when the next timer would fire, allowing the working thread to
sleep until the deadling.