### PR TITLE
metrics: add per-channel scaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "datastructures 0.2.1",
  "logger 0.1.0",
- "metrics 0.2.0",
+ "metrics 0.3.0",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -436,7 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "metrics"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "datastructures 0.2.1",
  "evmap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,7 +752,7 @@ dependencies = [
  "datastructures 0.2.1",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
- "metrics 0.2.0",
+ "metrics 0.3.0",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpmc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/metrics/examples/benchmarks.rs
+++ b/metrics/examples/benchmarks.rs
@@ -118,7 +118,7 @@ pub fn sized_run(
             "test".to_string()
         };
         let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
-        recorder.add_channel(label.clone(), source, Some(histogram_config));
+        recorder.add_channel(label.clone(), source, Some(histogram_config), 1);
         thread_pool.push(thread::spawn(move || {
             for value in 0..(max / threads) {
                 let measurement = match measurement_type {

--- a/metrics/src/channel.rs
+++ b/metrics/src/channel.rs
@@ -257,7 +257,9 @@ where
 
     pub fn percentile(&self, percentile: f64) -> Option<u64> {
         if let Some(ref histogram) = self.histogram {
-            histogram.percentile(percentile).map(|v| v * self.scale.get())
+            histogram
+                .percentile(percentile)
+                .map(|v| v * self.scale.get())
         } else {
             None
         }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         assert_eq!(recorder.percentile("test".to_string(), 0.0), None);
         recorder.record(
@@ -227,7 +227,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(2_000_000_000, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -282,7 +282,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(80_000_000_000, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::Counter, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         let data: Vec<u64> = vec![
             20334687810196614,
@@ -337,7 +337,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -373,7 +373,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Gauge, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::Gauge, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record("test".to_string(), Measurement::Gauge { value: 0, time: 1 });
         assert_eq!(recorder.counter("test".to_string()), 0);
@@ -399,7 +399,7 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::TimeInterval, Some(histogram_config));
+        recorder.add_channel(name.clone(), Source::TimeInterval, Some(histogram_config), 1);
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -423,5 +423,41 @@ mod tests {
         assert_eq!(recorder.percentile("test".to_string(), 0.99), Some(1));
         assert_eq!(recorder.percentile("test".to_string(), 0.999), Some(1));
         assert_eq!(recorder.percentile("test".to_string(), 1.00), Some(1));
+    }
+
+    #[test]
+    fn scaled_distribution_channel() {
+        let recorder = Recorder::<u64>::new();
+        let name = "test".to_string();
+        let histogram_config = HistogramBuilder::new(100, 3, None, None);
+        recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config), 1_000);
+        assert_eq!(recorder.counter("test".to_string()), 0);
+        recorder.record(
+            "test".to_string(),
+            Measurement::Distribution {
+                value: 1,
+                count: 1,
+                time: 0,
+            },
+        );
+        assert_eq!(recorder.counter("test".to_string()), 1_000);
+        for i in 2..101 {
+            recorder.record(
+                "test".to_string(),
+                Measurement::Distribution {
+                    value: i,
+                    count: 1,
+                    time: 0,
+                },
+            );
+        }
+        assert_eq!(recorder.counter("test".to_string()), 100_000);
+        assert_eq!(recorder.percentile("test".to_string(), 0.0), Some(1_000));
+        assert_eq!(recorder.percentile("test".to_string(), 0.50), Some(50_000));
+        assert_eq!(recorder.percentile("test".to_string(), 0.90), Some(90_000));
+        assert_eq!(recorder.percentile("test".to_string(), 0.95), Some(95_000));
+        assert_eq!(recorder.percentile("test".to_string(), 0.99), Some(99_000));
+        assert_eq!(recorder.percentile("test".to_string(), 0.999), Some(100_000));
+        assert_eq!(recorder.percentile("test".to_string(), 1.00), Some(100_000));
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -337,7 +337,12 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config), 1);
+        recorder.add_channel(
+            name.clone(),
+            Source::Distribution,
+            Some(histogram_config),
+            1,
+        );
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -399,7 +404,12 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::TimeInterval, Some(histogram_config), 1);
+        recorder.add_channel(
+            name.clone(),
+            Source::TimeInterval,
+            Some(histogram_config),
+            1,
+        );
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -430,7 +440,12 @@ mod tests {
         let recorder = Recorder::<u64>::new();
         let name = "test".to_string();
         let histogram_config = HistogramBuilder::new(100, 3, None, None);
-        recorder.add_channel(name.clone(), Source::Distribution, Some(histogram_config), 1_000);
+        recorder.add_channel(
+            name.clone(),
+            Source::Distribution,
+            Some(histogram_config),
+            1_000,
+        );
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),
@@ -457,7 +472,10 @@ mod tests {
         assert_eq!(recorder.percentile("test".to_string(), 0.90), Some(90_000));
         assert_eq!(recorder.percentile("test".to_string(), 0.95), Some(95_000));
         assert_eq!(recorder.percentile("test".to_string(), 0.99), Some(99_000));
-        assert_eq!(recorder.percentile("test".to_string(), 0.999), Some(100_000));
+        assert_eq!(
+            recorder.percentile("test".to_string(), 0.999),
+            Some(100_000)
+        );
         assert_eq!(recorder.percentile("test".to_string(), 1.00), Some(100_000));
     }
 }

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -68,9 +68,10 @@ where
         name: String,
         source: Source,
         histogram_config: Option<HistogramBuilder<C>>,
+        scale: u64,
     ) {
         debug!("add channel: {} source: {:?}", name, source);
-        let channel = Channel::new(name.clone(), source, histogram_config);
+        let channel = Channel::new(name.clone(), source, histogram_config, scale);
         if self
             .data_read
             .get_and(&name, |channel| channel.len())

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -327,7 +327,7 @@ impl Simple {
 
     pub fn add_counter_channel<T: ToString>(&self, label: T) {
         self.inner
-            .add_channel(label.to_string(), Source::Counter, None);
+            .add_channel(label.to_string(), Source::Counter, None, 1);
         self.inner.add_output(label.to_string(), Output::Counter);
     }
 
@@ -337,6 +337,7 @@ impl Simple {
             label.to_string(),
             Source::TimeInterval,
             Some(histogram_config),
+            1,
         );
         self.inner.add_output(label.to_string(), Output::Counter);
         self.inner
@@ -359,6 +360,7 @@ impl Simple {
             label.to_string(),
             Source::Distribution,
             Some(histogram_config),
+            1,
         );
         self.inner.add_output(label.to_string(), Output::Counter);
         self.inner


### PR DESCRIPTION
Adds a scale factor at the metrics channel level. This allows us
to store samples in higher units, such as KiB and report them in
a base unit like B.