### PR TITLE
datastructures: improve histogram performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
 name = "datastructures"
 version = "0.2.1"
 dependencies = [
+ "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -8,3 +8,10 @@ edition = "2018"
 logger = { path = "../logger" }
 parking_lot = "0.7.1"
 time = "0.1.42"
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "latched_histogram"
+harness = false

--- a/datastructures/benches/latched_histogram.rs
+++ b/datastructures/benches/latched_histogram.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use datastructures::*;
+
+fn latched_histogram_increment(c: &mut Criterion) {
+    let histogram = LatchedHistogram::<u64>::new(60_000_000_000, 3);
+    c.bench_function("latched histogram increment", move |b| {
+        b.iter(|| histogram.increment(1_000_000_000, 1))
+    });
+}
+
+fn latched_histogram_percentile(c: &mut Criterion) {
+    let histogram = LatchedHistogram::<u64>::new(60_000_000_000, 3);
+    histogram.increment(1_000_000_000, 1);
+    c.bench_function("latched histogram percentile", move |b| {
+        b.iter(|| histogram.percentile(1.0))
+    });
+}
+
+criterion_group!(
+    benches,
+    latched_histogram_increment,
+    latched_histogram_percentile,
+);
+criterion_main!(benches);

--- a/datastructures/src/histogram/latched.rs
+++ b/datastructures/src/histogram/latched.rs
@@ -64,15 +64,15 @@ where
         } else if value <= self.exact_max() {
             Ok(value as usize)
         } else {
+            let exact_max = self.exact_max as usize;
             let power = (value as f64).log10().floor() as usize;
             let divisor = 10_u64.pow((power - self.precision) as u32 + 1);
-            let base_offset = 10_usize.pow(self.precision as u32);
             let power_offset = (0.9
-                * (10_usize.pow(self.precision as u32) * (power - self.precision)) as f64)
+                * (exact_max * (power - self.precision)) as f64)
                 as usize;
             let remainder = value / divisor;
-            let shift = 10_usize.pow(self.precision as u32 - 1);
-            let index = base_offset + power_offset + remainder as usize - shift;
+            let shift = exact_max / 10;
+            let index = exact_max + power_offset + remainder as usize - shift;
             Ok(index)
         }
     }
@@ -86,14 +86,14 @@ where
         } else if index == self.buckets.len() - 1 {
             Ok(self.max)
         } else {
-            let shift = 10_usize.pow(self.precision as u32 - 1);
-            let base_offset = 10_usize.pow(self.precision as u32);
+            let exact_max = self.exact_max as usize;
+            let shift = exact_max / 10;
             let power = self.precision
-                + (index - base_offset) / (9 * 10_usize.pow(self.precision as u32 - 1));
+                + (index - exact_max) / (0.9 * exact_max as f64) as usize;
             let power_offset = (0.9
-                * (10_usize.pow(self.precision as u32) * (power - self.precision)) as f64)
+                * (exact_max * (power - self.precision)) as f64)
                 as usize;
-            let value = (index + shift - base_offset - power_offset) as u64
+            let value = (index + shift - exact_max - power_offset) as u64
                 * 10_u64.pow((power - self.precision + 1) as u32);
             Ok(value)
         }


### PR DESCRIPTION
Adds a benchmark for LatchedHistogram to measure increment and percentile
operations.

Simplifies some of the math around get_index and get_min_value to improve
performance. The increment microbenchmark went from 35ns -> 20ns on my
laptop.