### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "c2-chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +184,7 @@ dependencies = [
  "datastructures 0.3.0",
  "logger 0.1.0",
  "metrics 0.3.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -340,6 +349,15 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getrandom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +420,9 @@ dependencies = [
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -599,6 +620,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,12 +659,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -655,11 +703,35 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -806,7 +878,7 @@ dependencies = [
  "logger 0.1.0",
  "metrics 0.3.0",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimiter 0.3.0",
  "rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1091,7 +1163,8 @@ dependencies = [
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "png 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_distr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1165,6 +1238,7 @@ dependencies = [
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
@@ -1188,6 +1262,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
 "checksum hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "575fb7f1167f3b88ed825e90eb14918ac460461fdeaa3965c6a50951dee1c970"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
@@ -1218,13 +1293,19 @@ dependencies = [
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum png 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "63daf481fdd0defa2d1d2be15c674fbfa1b0fd71882c303a91f9a79b3252c359"
+"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+"checksum rand_distr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c37e54d811c5a51195156444e298a98ba57df6dca1e511f34d4791993883b921"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -16,7 +16,7 @@ criterion = "0.2"
 bytes = "0.4.12"
 crc = "1.8.1"
 datastructures = { path = "../datastructures" }
-rand = "0.6.4"
+rand = "0.7.0"
 logger = { path = "../logger" }
 metrics = { path = "../metrics" }
 time = "0.1.42"

--- a/datastructures/ffi/cdatastructures/src/counter.rs
+++ b/datastructures/ffi/cdatastructures/src/counter.rs
@@ -13,7 +13,6 @@
 //  limitations under the License.
 
 use datastructures::Counter;
-use libc::uint64_t;
 
 /// Create a new `Counter`
 #[no_mangle]
@@ -33,7 +32,7 @@ pub unsafe extern "C" fn counter_reset(ptr: *mut Counter<u64>) {
 
 /// Get the count stored in the `Counter`
 #[no_mangle]
-pub unsafe extern "C" fn counter_count(ptr: *mut Counter<u64>) -> uint64_t {
+pub unsafe extern "C" fn counter_count(ptr: *mut Counter<u64>) -> u64 {
     let counter = {
         assert!(!ptr.is_null());
         &mut *ptr
@@ -43,7 +42,7 @@ pub unsafe extern "C" fn counter_count(ptr: *mut Counter<u64>) -> uint64_t {
 
 /// Decrement the value of the `Counter` by count
 #[no_mangle]
-pub unsafe extern "C" fn counter_sub(ptr: *mut Counter<u64>, count: uint64_t) {
+pub unsafe extern "C" fn counter_sub(ptr: *mut Counter<u64>, count: u64) {
     let counter = {
         assert!(!ptr.is_null());
         &mut *ptr
@@ -62,7 +61,7 @@ pub unsafe extern "C" fn counter_free(ptr: *mut Counter<u64>) {
 
 /// Increment the value of the `Counter` by count
 #[no_mangle]
-pub unsafe extern "C" fn counter_add(ptr: *mut Counter<u64>, count: uint64_t) {
+pub unsafe extern "C" fn counter_add(ptr: *mut Counter<u64>, count: u64) {
     let counter = {
         assert!(!ptr.is_null());
         &mut *ptr

--- a/datastructures/ffi/cdatastructures/src/histogram.rs
+++ b/datastructures/ffi/cdatastructures/src/histogram.rs
@@ -13,11 +13,11 @@
 //  limitations under the License.
 
 use datastructures::Histogram;
-use libc::{c_float, uint32_t, uint64_t};
+use libc::c_float;
 
 /// Create a new `histogram`
 #[no_mangle]
-pub extern "C" fn histogram_new(max: uint64_t, precision: uint32_t) -> *mut Histogram<u64> {
+pub extern "C" fn histogram_new(max: u64, precision: u32) -> *mut Histogram<u64> {
     Box::into_raw(Box::new(Histogram::new(max, precision, None, None)))
 }
 
@@ -35,8 +35,8 @@ pub unsafe extern "C" fn histogram_clear(ptr: *mut Histogram<u64>) {
 #[no_mangle]
 pub unsafe extern "C" fn histogram_decrement(
     ptr: *mut Histogram<u64>,
-    value: uint64_t,
-    count: uint64_t,
+    value: u64,
+    count: u64,
 ) {
     let histogram = {
         assert!(!ptr.is_null());
@@ -58,8 +58,8 @@ pub unsafe extern "C" fn histogram_free(ptr: *mut Histogram<u64>) {
 #[no_mangle]
 pub unsafe extern "C" fn histogram_increment(
     ptr: *mut Histogram<u64>,
-    value: uint64_t,
-    count: uint64_t,
+    value: u64,
+    count: u64,
 ) {
     let histogram = {
         assert!(!ptr.is_null());
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn histogram_increment(
 pub unsafe extern "C" fn histogram_percentile(
     ptr: *mut Histogram<u64>,
     percentile: c_float,
-) -> uint64_t {
+) -> u64 {
     let histogram = {
         assert!(!ptr.is_null());
         &mut *ptr
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn histogram_percentile(
 
 /// Get the total of all counts for the `histogram`
 #[no_mangle]
-pub unsafe extern "C" fn histogram_total_count(ptr: *mut Histogram<u64>) -> uint64_t {
+pub unsafe extern "C" fn histogram_total_count(ptr: *mut Histogram<u64>) -> u64 {
     let histogram = {
         assert!(!ptr.is_null());
         &mut *ptr

--- a/rpc-perf/Cargo.toml
+++ b/rpc-perf/Cargo.toml
@@ -22,7 +22,7 @@ datastructures = { path = "../datastructures" }
 logger = { path = "../logger" }
 metrics = { path = "../metrics" }
 mio = "0.6.19"
-rand = "0.6.1"
+rand = "0.7.0"
 ratelimiter = { path = "../ratelimiter" }
 rustls = { version = "0.15.2", optional = true }
 serde = "1.0.94"

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -16,6 +16,9 @@ dejavu = "2.37.0"
 hsl = "0.1.1"
 logger = { path = "../logger" }
 png = "0.14.1"
-rand = "0.6.4"
 rusttype = "0.7.7"
 time = "0.1.42"
+
+[dev-dependencies]
+rand = "0.7.0"
+rand_distr = "0.2.1"

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -15,8 +15,8 @@
 #![allow(unused_imports)]
 use datastructures::{Heatmap, Histogram};
 use logger::*;
-use rand::distributions::{Alphanumeric, Distribution, Gamma, LogNormal, Normal, Pareto, Uniform};
 use rand::{thread_rng, Rng};
+use rand_distr::{Distribution, Normal};
 use std::collections::HashMap;
 
 fn main() {
@@ -31,7 +31,7 @@ fn main() {
     let histogram = Histogram::<u64>::new(1_000_000, 2, None, None);
     let heatmap = Heatmap::<u64>::new(1_000_000, 2, 1_000_000, 5_000_000_000);
 
-    let distribution = Normal::new(500.0, 250.0);
+    let distribution = Normal::new(500.0, 250.0).unwrap();
 
     let start = std::time::Instant::now();
 
@@ -43,7 +43,7 @@ fn main() {
         if now - start >= std::time::Duration::new(0, 1_000_000) {
             heatmap.latch();
         }
-        let value = distribution.sample(&mut thread_rng()).abs();
+        let value: f64 = distribution.sample(&mut thread_rng());
         let value = value.floor() as u64;
         histogram.increment(value, 1);
         heatmap.increment(time::precise_time_ns(), value, 1);


### PR DESCRIPTION
Updates dependencies for rand where distributions have been factored
out into their own crate.

Convert to using u32/u64 instead of deprecated libc types