### PR TITLE
metrics: change behavior of clear()

### DIFF
--- a/metrics/src/channel.rs
+++ b/metrics/src/channel.rs
@@ -279,7 +279,7 @@ where
         self.min.set(0, 0);
     }
 
-    pub fn clear(&self) {
+    pub fn zero(&self) {
         self.has_data.store(false, Ordering::SeqCst);
         self.last_write.set(0);
         self.counter.set(0);

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -254,7 +254,7 @@ mod tests {
             1,
             3
         ));
-        recorder.clear();
+        recorder.zero();
         assert_eq!(recorder.counter("test".to_string()), 0);
         recorder.record(
             "test".to_string(),

--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -148,11 +148,18 @@ where
         }
     }
 
-    pub fn clear(&self) {
+    pub fn zero(&self) {
         let labels = self.labels.lock().unwrap();
         for label in &*labels {
             self.data_read
-                .get_and(label, |channel| (*channel)[0].clear());
+                .get_and(label, |channel| (*channel)[0].zero());
+        }
+    }
+
+    pub fn clear(&self) {
+        let labels = self.labels.lock().unwrap();
+        for label in &*labels {
+            self.delete_channel(label.to_string());
         }
     }
 }

--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -115,12 +115,12 @@ fn do_warmup(config: &Config, recorder: &Simple) {
             }
 
             if warm >= 3 {
-                recorder.clear();
+                recorder.zero();
                 control.store(false, Ordering::SeqCst);
                 break;
             }
 
-            recorder.clear();
+            recorder.zero();
         }
 
         info!("Warmup complete.");

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -424,8 +424,8 @@ impl Simple {
         self.inner.hash_map()
     }
 
-    pub fn clear(&self) {
-        self.inner.clear();
+    pub fn zero(&self) {
+        self.inner.zero();
     }
 
     pub fn readings(&self) -> Vec<Reading> {


### PR DESCRIPTION
Previously, clear() would just zero out the data stored in the
recorder without removing channels that have been registered.

With this change, clear() behaves like it does on a HashMap and
actually removes registered channels. The new function, zero(),
can be used to zero the data stored, without deregistering all
of the channels.