### PR TITLE
metrics: expose a shrink_to_fit()

### DIFF
--- a/metrics/src/recorder.rs
+++ b/metrics/src/recorder.rs
@@ -157,10 +157,17 @@ where
     }
 
     pub fn clear(&self) {
-        let labels = self.labels.lock().unwrap();
-        for label in &*labels {
-            self.delete_channel(label.to_string());
-        }
+        let mut labels = self.labels.lock().unwrap();
+        let mut write = self.data_write.lock().unwrap();
+        labels.clear();
+        write.purge();
+        write.refresh();
+    }
+
+    pub fn shrink_to_fit(&self) {
+        let mut write = self.data_write.lock().unwrap();
+        write.fit_all();
+        write.refresh();
     }
 }
 


### PR DESCRIPTION
Exposes a `shrink_to_fit()` function on the `Recorder` to allow
for reducing the memory usage after metrics have been deregistered