### PR TITLE
ci: remove cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ os: linux
 dist: trusty
 sudo: required
 env: TYPE=default RUST_BACKTRACE=1
-cache:
-  directories:
-  - $HOME/.cargo
-  - $TRAVIS_BUILD_DIR/target
 script:
 - cargo build --verbose
 - cargo test --verbose


### PR DESCRIPTION
Problem

Caching in TravisCI frequently results in build timeouts while fetching
and extracting the cache files.

Solution

Remove the caching

Result

Builds should run more consistently
