### PR TITLE
Update redis.toml example protocol

### DIFF
--- a/rpc-perf/configs/redis.toml
+++ b/rpc-perf/configs/redis.toml
@@ -1,5 +1,5 @@
 [general]
-protocol = "redis_resp" # use the Redis RESP protocol
+protocol = "redisresp" # use the Redis RESP protocol
 interval = 60 # seconds
 windows = 5 # run for 5 intervals
 clients = 1 # use a single client thread


### PR DESCRIPTION
`#[serde(rename_all = "snake_case")]` doesn't seem  to convert RedisResp to redis_resp, there's an error saying the expected protocol is redisresp so this example doesn't work.