### PR TITLE
bugfix: pelikan_rds

### DIFF
--- a/rpc-perf/src/codec/mod.rs
+++ b/rpc-perf/src/codec/mod.rs
@@ -42,6 +42,7 @@ pub struct Command {
     ttl: Option<usize>,
     index: Option<u64>,
     count: Option<u64>,
+    esize: Option<usize>,
     watermark_low: Option<usize>,
     watermark_high: Option<usize>,
 }
@@ -55,6 +56,7 @@ impl Command {
             ttl: None,
             index: None,
             count: None,
+            esize: None,
             watermark_low: None,
             watermark_high: None,
         }
@@ -111,13 +113,13 @@ impl Command {
 
     pub fn sarray_create(
         key: String,
-        esize: String,
+        esize: usize,
         watermark_low: Option<usize>,
         watermark_high: Option<usize>,
     ) -> Command {
         let mut command = Command::new(Action::SarrayCreate);
         command.key = Some(key);
-        command.values = Some(vec![esize]);
+        command.esize = Some(esize);
         command.watermark_low = watermark_low;
         command.watermark_high = watermark_high;
         command
@@ -169,6 +171,10 @@ impl Command {
         command.key = Some(key);
         command.count = Some(items);
         command
+    }
+
+    pub fn esize(&self) -> Option<usize> {
+        self.esize
     }
 
     pub fn watermark_low(&self) -> Option<usize> {

--- a/rpc-perf/src/codec/pelikan_rds.rs
+++ b/rpc-perf/src/codec/pelikan_rds.rs
@@ -67,8 +67,7 @@ impl Codec for PelikanRds {
             }
             Action::SarrayCreate => {
                 let key = command.key().unwrap();
-                let values = command.values().unwrap();
-                let esize = values[0].len();
+                let esize = command.esize().unwrap();
                 if let Some(recorder) = self.common.recorder() {
                     recorder.increment("commands/create");
                     recorder.distribution("keys/size", key.len() as u64);

--- a/rpc-perf/src/config/mod.rs
+++ b/rpc-perf/src/config/mod.rs
@@ -134,7 +134,7 @@ impl Generator {
                 let esize = value.length();
                 crate::codec::Command::sarray_create(
                     key,
-                    format!("{}", esize),
+                    esize,
                     command.watermark_low(),
                     command.watermark_high(),
                 )


### PR DESCRIPTION
Problem

For pelikan_rds all `SArray.creats`s were issued for 1byte integers (u8)
instead of using the value length properly.

Solution

Add an `esize` field to the `Command` struct. Populate that directly
from the `Value::length()` and pass it directly to the codec.

Result

`SArray.create` correctly uses the value length.
