### PR TITLE
atomics: add serializer for atomic primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atomics"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -289,7 +289,7 @@ dependencies = [
 name = "datastructures"
 version = "0.4.0"
 dependencies = [
- "atomics 0.2.0",
+ "atomics 0.3.0",
  "logger 0.1.0",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +846,7 @@ dependencies = [
 name = "rpc-perf"
 version = "3.2.0-pre"
 dependencies = [
- "atomics 0.2.0",
+ "atomics 0.3.0",
  "buffer 0.1.0",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1130,7 +1130,7 @@ dependencies = [
 name = "waterfall"
 version = "0.4.0"
 dependencies = [
- "atomics 0.2.0",
+ "atomics 0.3.0",
  "datastructures 0.4.0",
  "dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/atomics/Cargo.toml
+++ b/atomics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomics"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/atomics/src/atomic_primitive/atomic_bool.rs
+++ b/atomics/src/atomic_primitive/atomic_bool.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// A boolean type which can be safely shared between threads.
 pub struct AtomicBool {
@@ -118,5 +118,16 @@ impl<'de> Deserialize<'de> for AtomicBool {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_bool(AtomicBoolVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicBool {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }

--- a/atomics/src/atomic_primitive/atomic_i16.rs
+++ b/atomics/src/atomic_primitive/atomic_i16.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicI16 {
@@ -192,6 +192,17 @@ impl<'de> Deserialize<'de> for AtomicI16 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_i16(AtomicI16Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicI16 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_i32.rs
+++ b/atomics/src/atomic_primitive/atomic_i32.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicI32 {
@@ -182,6 +182,17 @@ impl<'de> Deserialize<'de> for AtomicI32 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_i32(AtomicI32Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicI32 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_i64.rs
+++ b/atomics/src/atomic_primitive/atomic_i64.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicI64 {
@@ -172,6 +172,17 @@ impl<'de> Deserialize<'de> for AtomicI64 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_i64(AtomicI64Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicI64 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_i8.rs
+++ b/atomics/src/atomic_primitive/atomic_i8.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicI8 {
@@ -202,6 +202,17 @@ impl<'de> Deserialize<'de> for AtomicI8 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_i8(AtomicI8Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicI8 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_isize.rs
+++ b/atomics/src/atomic_primitive/atomic_isize.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicIsize {
@@ -192,6 +192,17 @@ impl<'de> Deserialize<'de> for AtomicIsize {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicIsizeVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicIsize {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_u16.rs
+++ b/atomics/src/atomic_primitive/atomic_u16.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicU16 {
@@ -197,6 +197,17 @@ impl<'de> Deserialize<'de> for AtomicU16 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicU16Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicU16 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_u32.rs
+++ b/atomics/src/atomic_primitive/atomic_u32.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicU32 {
@@ -192,6 +192,17 @@ impl<'de> Deserialize<'de> for AtomicU32 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicU32Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicU32 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_u64.rs
+++ b/atomics/src/atomic_primitive/atomic_u64.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicU64 {
@@ -187,6 +187,17 @@ impl<'de> Deserialize<'de> for AtomicU64 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicU64Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicU64 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_u8.rs
+++ b/atomics/src/atomic_primitive/atomic_u8.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicU8 {
@@ -202,6 +202,17 @@ impl<'de> Deserialize<'de> for AtomicU8 {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicU8Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicU8 {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_usize.rs
+++ b/atomics/src/atomic_primitive/atomic_usize.rs
@@ -5,7 +5,7 @@
 use crate::{AtomicPrimitive, Ordering};
 
 #[cfg(feature = "serde")]
-use serde::{de::Deserialize, de::Visitor, Deserializer};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 /// An integer type which can be safely shared between threads.
 pub struct AtomicUsize {
@@ -202,6 +202,17 @@ impl<'de> Deserialize<'de> for AtomicUsize {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(AtomicUsizeVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for AtomicUsize {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.load(Ordering::SeqCst))
     }
 }
 


### PR DESCRIPTION
Problem

Atomic primitives don't implement `Serialize`

Solution

Implement serde `Serialize` for all atomic primitives
