### PR TITLE
rpc-perf: close connections earlier

### DIFF
--- a/rpc-perf/src/session/mod.rs
+++ b/rpc-perf/src/session/mod.rs
@@ -123,7 +123,10 @@ pub trait Session: Read + Write {
 
     /// Set the `Session` `State`
     fn set_state(&mut self, state: State) {
-        self.common_mut().set_state(state)
+        self.common_mut().set_state(state);
+        if state == State::Closed {
+            self.stream_mut().close();
+        }
     }
 
     // timestamps

--- a/rpc-perf/src/session/stream.rs
+++ b/rpc-perf/src/session/stream.rs
@@ -57,6 +57,11 @@ impl Stream {
         Ok(())
     }
 
+    /// Closes the underlying stream by dropping it
+    pub fn close(&mut self) {
+        self.stream = None;
+    }
+
     /// Register the underlying stream with an event loop
     pub fn register(
         &self,


### PR DESCRIPTION
Problem

Previously, connections wouldn't close immediately after timeout.
Instead, they would be closed when a new connection is established.

Solution

Now, when the session is marked as closed, the socket will also be
closed.

