### PR TITLE
codec: fix benchmarks

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -9,6 +9,6 @@ if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS
     git checkout master && \
     cargo bench && \
     # Bench pull request
-    git checkout ${TRAVIS_COMMIT} && \
+    git checkout ${TRAVIS_BRANCH} && \
     cargo bench;
 fi

--- a/codec/benches/memcache.rs
+++ b/codec/benches/memcache.rs
@@ -10,7 +10,10 @@ fn encode_get_benchmark(c: &mut Criterion) {
     let codec = Memcache::new();
     let mut buf = BytesMut::new();
     c.bench_function("memcache encode get", move |b| {
-        b.iter(|| codec.get(&mut buf, b"0"))
+        b.iter(|| {
+            codec.get(&mut buf, b"0");
+            buf.clear();
+        })
     });
 }
 
@@ -18,7 +21,10 @@ fn encode_set_benchmark(c: &mut Criterion) {
     let codec = Memcache::new();
     let mut buf = BytesMut::new();
     c.bench_function("memcache encode set", move |b| {
-        b.iter(|| codec.set(&mut buf, b"0", b"0", None, None))
+        b.iter(|| {
+            codec.set(&mut buf, b"0", b"0", None, None);
+            buf.clear();
+        })
     });
 }
 

--- a/codec/benches/ping.rs
+++ b/codec/benches/ping.rs
@@ -8,11 +8,11 @@ use criterion::Criterion;
 
 fn encode_ping_benchmark(c: &mut Criterion) {
     let codec = Ping::new();
-    let mut buf = BytesMut::new();
+
     c.bench_function("ping encode", move |b| {
         b.iter(|| {
+            let mut buf = BytesMut::new();
             codec.ping(&mut buf);
-            buf.clear();
         })
     });
 }

--- a/codec/benches/ping.rs
+++ b/codec/benches/ping.rs
@@ -9,7 +9,12 @@ use criterion::Criterion;
 fn encode_ping_benchmark(c: &mut Criterion) {
     let codec = Ping::new();
     let mut buf = BytesMut::new();
-    c.bench_function("ping encode", move |b| b.iter(|| codec.ping(&mut buf)));
+    c.bench_function("ping encode", move |b| {
+        b.iter(|| {
+            codec.ping(&mut buf);
+            buf.clear();
+        })
+    });
 }
 
 fn ping_decode_benchmark(c: &mut Criterion, label: &str, msg: &[u8]) {

--- a/codec/benches/redis.rs
+++ b/codec/benches/redis.rs
@@ -10,7 +10,10 @@ fn encode_inline_get_benchmark(c: &mut Criterion) {
     let codec = Redis::new(RedisMode::Inline);
     let mut buf = BytesMut::new();
     c.bench_function("redis inline encode get", move |b| {
-        b.iter(|| codec.get(&mut buf, b"0"))
+        b.iter(|| {
+            codec.get(&mut buf, b"0");
+            buf.clear();
+        })
     });
 }
 
@@ -18,7 +21,10 @@ fn encode_inline_set_benchmark(c: &mut Criterion) {
     let codec = Redis::new(RedisMode::Inline);
     let mut buf = BytesMut::new();
     c.bench_function("redis inline encode set", move |b| {
-        b.iter(|| codec.set(&mut buf, b"0", b"0", None))
+        b.iter(|| {
+            codec.set(&mut buf, b"0", b"0", None);
+            buf.clear();
+        })
     });
 }
 
@@ -26,7 +32,10 @@ fn encode_resp_get_benchmark(c: &mut Criterion) {
     let codec = Redis::new(RedisMode::Resp);
     let mut buf = BytesMut::new();
     c.bench_function("redis resp encode get", move |b| {
-        b.iter(|| codec.get(&mut buf, b"0"))
+        b.iter(|| {
+            codec.get(&mut buf, b"0");
+            buf.clear();
+        })
     });
 }
 
@@ -34,7 +43,10 @@ fn encode_resp_set_benchmark(c: &mut Criterion) {
     let codec = Redis::new(RedisMode::Resp);
     let mut buf = BytesMut::new();
     c.bench_function("redis resp encode set", move |b| {
-        b.iter(|| codec.set(&mut buf, b"0", b"0", None))
+        b.iter(|| {
+            codec.set(&mut buf, b"0", b"0", None);
+            buf.clear();
+        })
     });
 }
 


### PR DESCRIPTION
Problem

Current codec benchmarks result in the buffer growing with each iteration

Solution

Clear buffer after each encode

Result

Buffer remains bounded in size
