### PR TITLE
rpc-perf: add basic redis list support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "codec"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -851,7 +851,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codec 0.2.0",
+ "codec 0.3.0",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "datastructures 0.4.0",
  "logger 0.1.0",

--- a/rpc-perf/src/codec/mod.rs
+++ b/rpc-perf/src/codec/mod.rs
@@ -62,9 +62,65 @@ impl Command {
         }
     }
 
+    pub fn delete(key: String) -> Command {
+        let mut command = Command::new(Action::Delete);
+        command.key = Some(key);
+        command
+    }
+
     pub fn get(key: String) -> Command {
         let mut command = Command::new(Action::Get);
         command.key = Some(key);
+        command
+    }
+
+    pub fn llen(key: String) -> Command {
+        let mut command = Command::new(Action::Llen);
+        command.key = Some(key);
+        command
+    }
+
+    pub fn lpush(key: String, values: Vec<String>) -> Command {
+        let mut command = Command::new(Action::Lpush);
+        command.key = Some(key);
+        command.values = Some(values);
+        command
+    }
+
+    pub fn lpushx(key: String, values: Vec<String>) -> Command {
+        let mut command = Command::new(Action::Lpushx);
+        command.key = Some(key);
+        command.values = Some(values);
+        command
+    }
+
+    pub fn lrange(key: String, index: usize, count: usize) -> Command {
+        let mut command = Command::new(Action::Lrange);
+        command.key = Some(key);
+        command.count = Some(count as u64);
+        command.index = Some(index as u64);
+        command
+    }
+
+    pub fn ltrim(key: String, index: usize, count: usize) -> Command {
+        let mut command = Command::new(Action::Lrange);
+        command.key = Some(key);
+        command.count = Some(count as u64);
+        command.index = Some(index as u64);
+        command
+    }
+
+    pub fn rpush(key: String, values: Vec<String>) -> Command {
+        let mut command = Command::new(Action::Rpush);
+        command.key = Some(key);
+        command.values = Some(values);
+        command
+    }
+
+    pub fn rpushx(key: String, values: Vec<String>) -> Command {
+        let mut command = Command::new(Action::Rpushx);
+        command.key = Some(key);
+        command.values = Some(values);
         command
     }
 

--- a/rpc-perf/src/codec/pelikan_rds.rs
+++ b/rpc-perf/src/codec/pelikan_rds.rs
@@ -16,6 +16,7 @@ use crate::codec::*;
 use crate::config::Action;
 
 use bytes::BytesMut;
+use logger::*;
 
 pub struct PelikanRds {
     codec: codec::PelikanRds,
@@ -145,6 +146,9 @@ impl Codec for PelikanRds {
                 }
                 self.codec
                     .sarray_truncate(buf, key, command.count.unwrap_or(0))
+            }
+            action => {
+                fatal!("Action: {:?} unsupported for pelikan_rds", action);
             }
         }
     }

--- a/rpc-perf/src/codec/redis.rs
+++ b/rpc-perf/src/codec/redis.rs
@@ -50,6 +50,15 @@ impl Codec for Redis {
     fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng) {
         let command = self.generate(rng);
         match command.action() {
+            Action::Delete => {
+                let key = command.key().unwrap();
+                let keys = vec![key];
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/delete");
+                    recorder.distribution("keys/size", key.len() as u64);
+                }
+                self.codec.delete(buf, &keys);
+            }
             Action::Get => {
                 let key = command.key().unwrap();
                 if let Some(recorder) = self.common.recorder() {
@@ -57,6 +66,76 @@ impl Codec for Redis {
                     recorder.distribution("keys/size", key.len() as u64);
                 }
                 self.codec.get(buf, key);
+            }
+            Action::Llen => {
+                let key = command.key().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/len");
+                    recorder.distribution("keys/size", key.len() as u64);
+                }
+                self.codec.llen(buf, key);
+            }
+            Action::Lpush => {
+                let key = command.key().unwrap();
+                let values = command.values().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/push");
+                    recorder.distribution("keys/size", key.len() as u64);
+                    let len: usize = values.iter().map(|v| v.len()).sum();
+                    recorder.distribution("values/size", len as u64);
+                }
+                self.codec.lpush(buf, key, &values);
+            }
+            Action::Lpushx => {
+                let key = command.key().unwrap();
+                let values = command.values().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/push");
+                    recorder.distribution("keys/size", key.len() as u64);
+                    let len: usize = values.iter().map(|v| v.len()).sum();
+                    recorder.distribution("values/size", len as u64);
+                }
+                self.codec.lpushx(buf, key, &values);
+            }
+            Action::Lrange => {
+                let key = command.key().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/range");
+                    recorder.distribution("keys/size", key.len() as u64);
+                }
+                // TODO: proper handling of start and stop
+                self.codec.lrange(buf, key, 0, command.count.unwrap_or(1) as isize);
+            }
+            Action::Ltrim => {
+                let key = command.key().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/trim");
+                    recorder.distribution("keys/size", key.len() as u64);
+                }
+                // TODO: proper handling of start and stop
+                self.codec.lrange(buf, key, 0, command.count.unwrap_or(1) as isize);
+            }
+            Action::Rpush => {
+                let key = command.key().unwrap();
+                let values = command.values().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/push");
+                    recorder.distribution("keys/size", key.len() as u64);
+                    let len: usize = values.iter().map(|v| v.len()).sum();
+                    recorder.distribution("values/size", len as u64);
+                }
+                self.codec.rpush(buf, key, &values);
+            }
+            Action::Rpushx => {
+                let key = command.key().unwrap();
+                let values = command.values().unwrap();
+                if let Some(recorder) = self.common.recorder() {
+                    recorder.increment("commands/push");
+                    recorder.distribution("keys/size", key.len() as u64);
+                    let len: usize = values.iter().map(|v| v.len()).sum();
+                    recorder.distribution("values/size", len as u64);
+                }
+                self.codec.rpushx(buf, key, &values);
             }
             Action::Set => {
                 let key = command.key().unwrap();

--- a/rpc-perf/src/config/mod.rs
+++ b/rpc-perf/src/config/mod.rs
@@ -83,7 +83,15 @@ impl Default for Config {
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum Action {
+    Delete,
     Get,
+    Llen,
+    Lpush,
+    Lpushx,
+    Lrange,
+    Ltrim,
+    Rpush,
+    Rpushx,
     SarrayCreate,
     SarrayDelete,
     SarrayFind,
@@ -119,9 +127,53 @@ impl Generator {
         let command = keyspace.choose_command(rng);
         let action = command.action();
         match action {
+            Action::Delete => {
+                let key = keyspace.choose_key(rng);
+                crate::codec::Command::delete(key)
+            }
             Action::Get => {
                 let key = keyspace.choose_key(rng);
                 crate::codec::Command::get(key)
+            }
+            Action::Llen => {
+                let key = keyspace.choose_key(rng);
+                crate::codec::Command::llen(key)
+            }
+            Action::Lpush => {
+                let key = keyspace.choose_key(rng);
+                let mut values = Vec::new();
+                for _ in 0..command.items().unwrap_or(1) {
+                    values.push(keyspace.choose_value_string(rng));
+                }
+                crate::codec::Command::lpush(key, values)
+            }
+            Action::Lpushx => {
+                let key = keyspace.choose_key(rng);
+                let mut values = Vec::new();
+                values.push(keyspace.choose_value_string(rng));
+                crate::codec::Command::lpushx(key, values)
+            }
+            Action::Lrange => {
+                let key = keyspace.choose_key(rng);
+                crate::codec::Command::lrange(key, 0, command.items().unwrap_or(1))
+            }
+            Action::Ltrim => {
+                let key = keyspace.choose_key(rng);
+                crate::codec::Command::ltrim(key, 0, command.items().unwrap_or(1))
+            }
+            Action::Rpush => {
+                let key = keyspace.choose_key(rng);
+                let mut values = Vec::new();
+                for _ in 0..command.items().unwrap_or(1) {
+                    values.push(keyspace.choose_value_string(rng));
+                }
+                crate::codec::Command::rpush(key, values)
+            }
+            Action::Rpushx => {
+                let key = keyspace.choose_key(rng);
+                let mut values = Vec::new();
+                values.push(keyspace.choose_value_string(rng));
+                crate::codec::Command::rpushx(key, values)
             }
             Action::Set => {
                 let key = keyspace.choose_key(rng);


### PR DESCRIPTION
Problem

No benchmarking support for redis list commands

Solution

Adds basic support for benchmarking redis list commands: llen,
lpush, lpushx, lrange, ltrim, rpush, rpushx