### PR TITLE
rpc-perf: bugfix redis ltrim

### DIFF
--- a/rpc-perf/src/codec/redis.rs
+++ b/rpc-perf/src/codec/redis.rs
@@ -113,7 +113,7 @@ impl Codec for Redis {
                     recorder.distribution("keys/size", key.len() as u64);
                 }
                 // TODO: proper handling of start and stop
-                self.codec.lrange(buf, key, 0, command.count.unwrap_or(1) as isize);
+                self.codec.ltrim(buf, key, 0, command.count.unwrap_or(1) as isize);
             }
             Action::Rpush => {
                 let key = command.key().unwrap();


### PR DESCRIPTION
Problem

Instead of issuing an `ltrim`, an `lrange` was being issued

Solution

Changed code to issue an `ltrim`