### PR TITLE
rpc-perf: add soft-timeout mode

### DIFF
--- a/rpc-perf/src/client/common.rs
+++ b/rpc-perf/src/client/common.rs
@@ -46,6 +46,7 @@ pub struct Common {
     timers: Wheel<Token>,
     last_timeouts: u64,
     tcp_nodelay: bool,
+    soft_timeout: bool,
 }
 
 impl Common {
@@ -67,6 +68,7 @@ impl Common {
             timers: Wheel::<Token>::new(SECOND / MICROSECOND),
             last_timeouts: time::precise_time_ns(),
             tcp_nodelay: false,
+            soft_timeout: false,
         }
     }
 
@@ -104,6 +106,14 @@ impl Common {
 
     pub fn set_request_ratelimit(&mut self, ratelimiter: Option<Arc<Ratelimiter>>) {
         self.request_ratelimiter = ratelimiter;
+    }
+
+    pub fn set_soft_timeout(&mut self, enabled: bool) {
+        self.soft_timeout = enabled;
+    }
+
+    pub fn soft_timeout(&self) -> bool {
+        self.soft_timeout
     }
 
     pub fn try_request_wait(&self) -> Result<(), ()> {

--- a/rpc-perf/src/codec/redis.rs
+++ b/rpc-perf/src/codec/redis.rs
@@ -104,7 +104,8 @@ impl Codec for Redis {
                     recorder.distribution("keys/size", key.len() as u64);
                 }
                 // TODO: proper handling of start and stop
-                self.codec.lrange(buf, key, 0, command.count.unwrap_or(1) as isize);
+                self.codec
+                    .lrange(buf, key, 0, command.count.unwrap_or(1) as isize);
             }
             Action::Ltrim => {
                 let key = command.key().unwrap();
@@ -113,7 +114,8 @@ impl Codec for Redis {
                     recorder.distribution("keys/size", key.len() as u64);
                 }
                 // TODO: proper handling of start and stop
-                self.codec.ltrim(buf, key, 0, command.count.unwrap_or(1) as isize);
+                self.codec
+                    .ltrim(buf, key, 0, command.count.unwrap_or(1) as isize);
             }
             Action::Rpush => {
                 let key = command.key().unwrap();

--- a/rpc-perf/src/config/general.rs
+++ b/rpc-perf/src/config/general.rs
@@ -46,6 +46,8 @@ pub struct General {
     #[serde(default = "default_connect_timeout")]
     connect_timeout: usize,
     waterfall: Option<String>,
+    #[serde(default = "default_soft_timeout")]
+    soft_timeout: bool,
 }
 
 impl General {
@@ -131,6 +133,14 @@ impl General {
 
     pub fn connect_timeout(&self) -> usize {
         self.connect_timeout
+    }
+
+    pub fn set_soft_timeout(&mut self, enabled: bool) {
+        self.soft_timeout = enabled;
+    }
+
+    pub fn soft_timeout(&self) -> bool {
+        self.soft_timeout
     }
 
     pub fn set_connect_ratelimit(&mut self, per_second: Option<usize>) {
@@ -230,6 +240,7 @@ impl Default for General {
             request_timeout: default_request_timeout(),
             connect_timeout: default_connect_timeout(),
             waterfall: None,
+            soft_timeout: false,
         }
     }
 }
@@ -260,6 +271,10 @@ fn default_request_timeout() -> usize {
 
 fn default_connect_timeout() -> usize {
     200 * MILLISECOND / MICROSECOND
+}
+
+fn default_soft_timeout() -> bool {
+    false
 }
 
 #[derive(Copy, Clone, Deserialize, Debug)]

--- a/rpc-perf/src/config/mod.rs
+++ b/rpc-perf/src/config/mod.rs
@@ -503,6 +503,11 @@ impl Config {
                     .takes_value(true),
             )
             .arg(
+                Arg::with_name("soft-timeout")
+                    .long("soft_timeout")
+                    .help("Don't close connection on timeout"),
+            )
+            .arg(
                 Arg::with_name("close-rate")
                     .long("close-rate")
                     .value_name("Per-second")
@@ -610,6 +615,10 @@ impl Config {
 
         if let Some(close_rate) = parse_numeric_arg(&matches, "close-rate") {
             config.general.set_close_rate(Some(close_rate));
+        }
+
+        if matches.is_present("soft-timeout") {
+            config.general.set_soft_timeout(true);
         }
 
         if let Some(warmup_hitrate) = parse_float_arg(&matches, "warmup-hitrate") {
@@ -752,6 +761,10 @@ impl Config {
         self.general.connect_ratelimit()
     }
 
+    pub fn soft_timeout(&self) -> bool {
+        self.general.soft_timeout()
+    }
+
     pub fn close_rate(&self) -> Option<usize> {
         self.general.close_rate()
     }
@@ -835,9 +848,10 @@ impl Config {
                 .unwrap_or_else(|| "Unlimited".to_string()),
         );
         info!(
-            "Config: Timeout (us): Connect: {} Request: {}",
+            "Config: Timeout (us): Connect: {} Request: {} Mode: {}",
             self.connect_timeout(),
             self.request_timeout(),
+            if self.soft_timeout() { "Soft" } else { "Hard" },
         );
         let windows = self
             .windows()

--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -212,6 +212,7 @@ fn launch_clients(config: &Config, metrics: &stats::Simple, control: Arc<AtomicB
         client.set_stats(metrics.recorder());
         client.set_connect_timeout(config.connect_timeout());
         client.set_request_timeout(config.request_timeout());
+        client.set_soft_timeout(config.soft_timeout());
 
         let endpoints = config.endpoints();
 


### PR DESCRIPTION
Problem

Existing timeout behavior is to always close a connection, or give up on
the attempt to create a connection. Often, timeouts are due to load on
the backend, not network issues. In some cases, it may be beneficial to
wait until the connection is established or request is complete, even if it
exceeds timeout values.

Solution

Adds a "soft timeout" mode. In this mode, timeouts will count as timeouts,
but instead of closing the socket, we still wait for the connection to become
established or a response to be received.

Result

It will be possible to see error rates like a client would see, while still getting
an accurate representation of server latency.
