### PR TITLE
rpc-perf: fix warnings about explicit dyn

### DIFF
--- a/rpc-perf/src/client/common.rs
+++ b/rpc-perf/src/client/common.rs
@@ -37,7 +37,7 @@ pub struct Common {
     connect_timeout: usize,
     events: Option<Events>,
     event_loop: Poll,
-    codec: Box<Codec>,
+    codec: Box<dyn Codec>,
     poolsize: usize,
     ready_queue: VecDeque<Token>,
     request_ratelimiter: Option<Arc<Ratelimiter>>,
@@ -50,7 +50,7 @@ pub struct Common {
 }
 
 impl Common {
-    pub fn new(id: usize, codec: Box<Codec>) -> Self {
+    pub fn new(id: usize, codec: Box<dyn Codec>) -> Self {
         Self {
             id,
             close_rate: None,

--- a/rpc-perf/src/client/mod.rs
+++ b/rpc-perf/src/client/mod.rs
@@ -93,8 +93,8 @@ pub trait Client: Send {
         }
     }
     fn does_negotiate(&self) -> bool;
-    fn session(&self, token: Token) -> &Session;
-    fn session_mut(&mut self, token: Token) -> &mut Session;
+    fn session(&self, token: Token) -> &dyn Session;
+    fn session_mut(&mut self, token: Token) -> &mut dyn Session;
 
     fn prepare_request(&mut self, token: Token, rng: &mut ThreadRng);
 

--- a/rpc-perf/src/client/plain_client.rs
+++ b/rpc-perf/src/client/plain_client.rs
@@ -33,7 +33,7 @@ pub struct PlainClient {
 
 impl PlainClient {
     /// Create a new `PlainClient` which will send requests from the queue and parse the responses
-    pub fn new(id: usize, codec: Box<Codec>) -> PlainClient {
+    pub fn new(id: usize, codec: Box<dyn Codec>) -> PlainClient {
         Self {
             common: Common::new(id, codec),
             sessions: Slab::new(),
@@ -61,11 +61,11 @@ impl Client for PlainClient {
         &mut self.common
     }
 
-    fn session(&self, token: Token) -> &Session {
+    fn session(&self, token: Token) -> &dyn Session {
         &self.sessions[token.into()]
     }
 
-    fn session_mut(&mut self, token: Token) -> &mut Session {
+    fn session_mut(&mut self, token: Token) -> &mut dyn Session {
         &mut self.sessions[token.into()]
     }
 

--- a/rpc-perf/src/client/tls_client.rs
+++ b/rpc-perf/src/client/tls_client.rs
@@ -31,7 +31,7 @@ pub struct TLSClient {
 
 impl TLSClient {
     /// Creates a new `TLSClient` which sends requests from the queue and parses responses
-    pub fn new(id: usize, codec: Box<Codec>) -> TLSClient {
+    pub fn new(id: usize, codec: Box<dyn Codec>) -> TLSClient {
         Self {
             common: Common::new(id, codec),
             sessions: Slab::new(),
@@ -108,11 +108,11 @@ impl Client for TLSClient {
         &mut self.common
     }
 
-    fn session(&self, token: Token) -> &Session {
+    fn session(&self, token: Token) -> &dyn Session {
         &self.sessions[token.into()]
     }
 
-    fn session_mut(&mut self, token: Token) -> &mut Session {
+    fn session_mut(&mut self, token: Token) -> &mut dyn Session {
         &mut self.sessions[token.into()]
     }
 

--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -150,7 +150,7 @@ fn make_client(id: usize, codec: Box<Codec>, config: &Config) -> Box<Client> {
 }
 
 #[cfg(not(feature = "tls"))]
-fn make_client(id: usize, codec: Box<Codec>, _config: &Config) -> Box<Client> {
+fn make_client(id: usize, codec: Box<dyn Codec>, _config: &Config) -> Box<dyn Client> {
     Box::new(PlainClient::new(id, codec))
 }
 
@@ -186,7 +186,7 @@ fn launch_clients(config: &Config, metrics: &stats::Simple, control: Arc<AtomicB
     };
 
     for i in 0..config.clients() {
-        let mut codec: Box<Codec> = match config.protocol() {
+        let mut codec: Box<dyn Codec> = match config.protocol() {
             Protocol::Echo => Box::new(crate::codec::Echo::new()),
             Protocol::Memcache => Box::new(crate::codec::Memcache::new()),
             Protocol::PelikanRds => Box::new(crate::codec::PelikanRds::new()),


### PR DESCRIPTION
Problem

Trait objects without an explicit `dyn` are deprecated.

Solution

Fix code to include explicit `dyn`
