### PR TITLE
rpc-perf: use declarations

### DIFF
--- a/rpc-perf/src/client/common.rs
+++ b/rpc-perf/src/client/common.rs
@@ -14,8 +14,7 @@
 
 use crate::client::{MICROSECOND, MILLISECOND, SECOND};
 use crate::codec::Codec;
-use crate::stats::SimpleRecorder;
-use crate::stats::Stat;
+use crate::stats::{SimpleRecorder, Stat};
 
 use bytes::BytesMut;
 use logger::*;

--- a/rpc-perf/src/client/mod.rs
+++ b/rpc-perf/src/client/mod.rs
@@ -17,20 +17,18 @@ mod plain_client;
 #[cfg(feature = "tls")]
 mod tls_client;
 
-use crate::codec::*;
-use crate::stats::SimpleRecorder;
-use rand::rngs::ThreadRng;
-
 pub use crate::client::common::Common;
 pub use crate::client::plain_client::PlainClient;
 #[cfg(feature = "tls")]
 pub use crate::client::tls_client::TLSClient;
+use crate::codec::*;
 use crate::session::*;
-use crate::stats::Stat;
+use crate::stats::{SimpleRecorder, Stat};
 use crate::*;
 
 use mio::unix::UnixReady;
 use mio::{Event, Events, Poll, PollOpt, Ready, Token};
+use rand::rngs::ThreadRng;
 use ratelimiter::Ratelimiter;
 
 use std::net::SocketAddr;

--- a/rpc-perf/src/client/plain_client.rs
+++ b/rpc-perf/src/client/plain_client.rs
@@ -15,12 +15,11 @@
 use crate::client::common::Common;
 use crate::client::Client;
 use crate::codec::Codec;
-use crate::session::PlainSession;
-use crate::session::Session;
-use rand::rngs::ThreadRng;
+use crate::session::{PlainSession, Session};
 
 use logger::*;
 use mio::Token;
+use rand::rngs::ThreadRng;
 use slab::Slab;
 
 use std::net::SocketAddr;

--- a/rpc-perf/src/client/tls_client.rs
+++ b/rpc-perf/src/client/tls_client.rs
@@ -12,12 +12,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use super::*;
+use crate::client::*;
 use crate::session::{Session, TLSSession};
+
 use mio::Token;
 use rustls;
 use rustls::ClientConfig;
 use slab::Slab;
+
 use std::fs;
 use std::io::BufReader;
 use std::sync::Arc;

--- a/rpc-perf/src/codec/mod.rs
+++ b/rpc-perf/src/codec/mod.rs
@@ -12,12 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use crate::config::Config;
-use crate::config::Generator;
-use crate::stats::SimpleRecorder;
-use bytes::BytesMut;
-use rand::rngs::ThreadRng;
-
 mod echo;
 mod memcache;
 mod pelikan_rds;
@@ -29,11 +23,14 @@ pub use crate::codec::memcache::Memcache;
 pub use crate::codec::pelikan_rds::PelikanRds;
 pub use crate::codec::ping::Ping;
 pub use crate::codec::redis::{Redis, RedisMode};
-pub use codec::Decoder;
-pub use codec::Error;
-pub use codec::Response;
 
-use crate::config::Action;
+pub use codec::{Decoder, Error, Response};
+
+use crate::config::{Action, Config, Generator};
+use crate::stats::SimpleRecorder;
+
+use bytes::BytesMut;
+use rand::rngs::ThreadRng;
 
 pub struct Command {
     action: Action,

--- a/rpc-perf/src/codec/redis.rs
+++ b/rpc-perf/src/codec/redis.rs
@@ -12,9 +12,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use crate::codec::*;
 pub use codec::RedisMode;
 
+use crate::codec::*;
 use crate::config::Action;
 
 use bytes::BytesMut;

--- a/rpc-perf/src/config/mod.rs
+++ b/rpc-perf/src/config/mod.rs
@@ -19,16 +19,16 @@ pub use self::general::Protocol;
 use crate::config::general::General;
 use crate::*;
 
-use std::io::Read;
-use std::net::{SocketAddr, ToSocketAddrs};
-use std::process;
-
 use clap::{App, Arg, ArgMatches};
 use rand::distributions::{Alphanumeric, Distribution, Uniform};
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde_derive::*;
+
+use std::io::Read;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::process;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const NAME: &str = env!("CARGO_PKG_NAME");

--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -18,21 +18,20 @@ mod config;
 mod session;
 mod stats;
 
+pub(crate) use logger::*;
+
 use crate::client::*;
 use crate::codec::Codec;
 use crate::config::Config;
 use crate::config::Protocol;
 use crate::stats::*;
-use atomics::AtomicPrimitive;
 
-use datastructures::AtomicBool;
-pub(crate) use logger::*;
+use atomics::{AtomicBool, AtomicPrimitive, Ordering};
 use metrics::Reading;
+use rand::thread_rng;
 use ratelimiter::Ratelimiter;
 
-use rand::thread_rng;
-
-use std::sync::{atomic::Ordering, Arc, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/rpc-perf/src/session/mod.rs
+++ b/rpc-perf/src/session/mod.rs
@@ -12,12 +12,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use crate::*;
-use bytes::BytesMut;
-
-use mio::{Poll, PollOpt, Ready, Token};
-use std::io::{Error, Read, Write};
-
 mod plain_session;
 mod stream;
 #[cfg(feature = "tls")]
@@ -27,6 +21,12 @@ pub use crate::session::plain_session::PlainSession;
 pub use crate::session::stream::Stream;
 #[cfg(feature = "tls")]
 pub use crate::session::tls_session::TLSSession;
+
+use crate::*;
+use bytes::BytesMut;
+use mio::{Poll, PollOpt, Ready, Token};
+
+use std::io::{Error, Read, Write};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 /// All possible states for a `Session`

--- a/rpc-perf/src/session/plain_session.rs
+++ b/rpc-perf/src/session/plain_session.rs
@@ -12,10 +12,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use crate::session::*;
+
 use buffer::Buffer;
 use bytes::BytesMut;
-
-use crate::session::*;
 
 use std::{fmt::Display, io::Error, io::ErrorKind, io::Read, io::Write, net::ToSocketAddrs};
 

--- a/rpc-perf/src/session/stream.rs
+++ b/rpc-perf/src/session/stream.rs
@@ -14,18 +14,11 @@
 
 use mio::event::Evented;
 use mio::net::TcpStream;
-use mio::Poll;
-use mio::PollOpt;
-use mio::Ready;
-use mio::Token;
+use mio::{Poll, PollOpt, Ready, Token};
 
 use std::fmt::Display;
-use std::io::Error;
-use std::io::ErrorKind;
-use std::io::Read;
-use std::io::Write;
-use std::net::SocketAddr;
-use std::net::ToSocketAddrs;
+use std::io::{Error, ErrorKind, Read, Write};
+use std::net::{SocketAddr, ToSocketAddrs};
 
 /// Holds the `Stream`'s address and underlying stream
 pub struct Stream {

--- a/rpc-perf/src/session/tls_session.rs
+++ b/rpc-perf/src/session/tls_session.rs
@@ -12,11 +12,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+use crate::session::*;
+
 use buffer::Buffer;
 use rustls::Session as OtherSession;
 use rustls::{ClientConfig, ClientSession};
-
-use crate::session::*;
 
 use std::{
     fmt::Display, io::Error, io::ErrorKind, io::Read, io::Write, net::ToSocketAddrs, sync::Arc,

--- a/rpc-perf/src/stats/http.rs
+++ b/rpc-perf/src/stats/http.rs
@@ -16,8 +16,9 @@ use crate::stats::SimpleRecorder;
 
 use logger::*;
 use metrics::{Output, Percentile, Reading};
-use std::net::SocketAddr;
 use tiny_http::{Method, Response, Server};
+
+use std::net::SocketAddr;
 
 pub struct Http {
     recorder: SimpleRecorder,

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -14,17 +14,17 @@
 
 pub mod http;
 
+pub use crate::stats::http::Http;
+
 use crate::client::SECOND;
 use crate::config::Config;
-pub use crate::stats::http::Http;
-use datastructures::Heatmap;
-use std::sync::Arc;
 
+use datastructures::Heatmap;
+use logger::*;
 use metrics::*;
 
 use std::collections::HashMap;
-
-use logger::*;
+use std::sync::Arc;
 
 pub fn register_stats(recorder: &SimpleRecorder) {
     recorder.add_counter_channel(Stat::CommandsGet);


### PR DESCRIPTION
Organize the use declarations based on `crate::`, `self::`, crate,
or `std`/`core` as well as by visibility