### PR TITLE
codec: fix logging

### DIFF
--- a/codec/src/pelikan_rds/mod.rs
+++ b/codec/src/pelikan_rds/mod.rs
@@ -5,6 +5,7 @@
 use super::*;
 
 use bytes::{Buf, BytesMut, IntoBuf};
+use logger::*;
 
 use std::io::{BufRead, BufReader};
 use std::str;
@@ -219,7 +220,8 @@ impl Decoder for PelikanRds {
                                 if have < expected {
                                     Err(Error::Incomplete)
                                 } else if have > expected {
-                                    println!("have: {} expected: {}", have, expected);
+                                    trace!("line: {}", line);
+                                    trace!("have: {} expected: {}", have, expected);
                                     Err(Error::Error)
                                 } else {
                                     Ok(Response::Hit)

--- a/codec/src/redis/mod.rs
+++ b/codec/src/redis/mod.rs
@@ -5,6 +5,7 @@
 use super::*;
 
 use bytes::{Buf, BytesMut, IntoBuf};
+use logger::*;
 
 use std::io::{BufRead, BufReader};
 use std::str;
@@ -202,7 +203,8 @@ impl Decoder for Redis {
                                 if have < expected {
                                     Err(Error::Incomplete)
                                 } else if have > expected {
-                                    println!("have: {} expected: {}", have, expected);
+                                    trace!("line: {}", line);
+                                    trace!("have: {} expected: {}", have, expected);
                                     Err(Error::Error)
                                 } else {
                                     Ok(Response::Hit)


### PR DESCRIPTION
Problem

Stray `println!()` logging in Redis and PelikanRDS codecs.

Solution

Change logging to use the `trace!()` macro instead
