### PR TITLE
atomics: improve documentation

### DIFF
--- a/atomics/src/lib.rs
+++ b/atomics/src/lib.rs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+//! A collection of atomic types which are unified through traits to allow for
+//! use as generic types in other datastructures. Also provides non standard
+//! atomic types such as an atomic `Option` type.
+
 mod atomic_counter;
 mod atomic_option;
 mod atomic_primitive;


### PR DESCRIPTION
Adds rustdoc with examples for `AtomicOption`. Adds module-level
rustdoc for atomics.
