### PR TITLE
datastructures: minor fixes and improved docs

### DIFF
--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+//! A collection of atomic datastructures
+
 pub use atomics::*;
 
 mod buffer;


### PR DESCRIPTION
Minor fixes for Histogram `mean()` and `mode()` to return an option
to account for when the Histogram is empty.

Improved documentation for datastructures to include examples.