### PR TITLE
ratelimiter: improve docs and fix example

### DIFF
--- a/ratelimiter/examples/blastoff.rs
+++ b/ratelimiter/examples/blastoff.rs
@@ -8,8 +8,9 @@ use ratelimiter::Ratelimiter;
 fn main() {
     let limiter = Ratelimiter::new(1, 1, 1);
     for i in 0..10 {
-        limiter.wait();
+    	limiter.wait();
         println!("T -{}", 10 - i);
     }
+    limiter.wait();
     println!("Ignition");
 }

--- a/ratelimiter/src/lib.rs
+++ b/ratelimiter/src/lib.rs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+//! This library provides a thread safe token bucket ratelimitier
+
 use datastructures::*;
 
+/// A token bucket ratelimiter
 pub struct Ratelimiter {
     available: AtomicU64,
     capacity: AtomicU64,
@@ -14,7 +17,24 @@ pub struct Ratelimiter {
 
 const SECOND: u64 = 1_000_000_000;
 
+/// A token bucket ratelimiter
 impl Ratelimiter {
+    /// Create a new token bucket `Ratelimiter` which can hold up to `capacity`
+    /// tokens. `quantum` tokens will be added to the bucket at `rate` times
+    /// per second. The token bucket initially starts without any tokens, this
+    /// ensures the rate does not start high initially.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratelimiter::*;
+    ///
+    /// // ratelimit to 1/s with no burst capacity
+    /// let ratelimiter = Ratelimiter::new(1, 1, 1);
+    ///
+    /// // ratelimit to 100/s with bursts up to 10
+    /// let ratelimiter = Ratelimiter::new(10, 1, 100);
+    /// ```
     pub fn new(capacity: u64, quantum: u64, rate: u64) -> Self {
         Self {
             available: AtomicU64::default(),
@@ -25,7 +45,8 @@ impl Ratelimiter {
         }
     }
 
-    pub fn tick(&self) {
+    // internal function to move the time forward
+    fn tick(&self) {
         let now = time::precise_time_ns();
         let next = self.next.get();
         if now >= next {
@@ -37,6 +58,22 @@ impl Ratelimiter {
         }
     }
 
+    /// Non-blocking wait for one token, returns an `Ok` if a token was
+    /// successfully acquired, returns an `Err` if it would block.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratelimiter::*;
+    ///
+    /// let ratelimiter = Ratelimiter::new(1, 1, 100);
+    /// for i in 0..100 {
+    ///     // do some work here
+    ///     while ratelimiter.try_wait().is_err() {
+    ///         // do some other work
+    ///     }
+    /// }
+    /// ```
     pub fn try_wait(&self) -> Result<(), ()> {
         self.tick();
         if self.available.get() > 0 {
@@ -45,15 +82,23 @@ impl Ratelimiter {
         } else {
             Err(())
         }
-        // self.available.try_decrement(1)
     }
 
+    /// Blocking wait implemented as a busy loop. Returns only after a token is
+    /// successfully acquired
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratelimiter::*;
+    ///
+    /// let ratelimiter = Ratelimiter::new(1, 1, 100);
+    /// for i in 0..100 {
+    ///     // do some work here
+    ///     ratelimiter.wait();
+    /// }
+    /// ```
     pub fn wait(&self) {
-        // TODO: this can be rewritten as a while loop
-        loop {
-            if self.try_wait().is_ok() {
-                break;
-            }
-        }
+        while self.try_wait().is_err() { }
     }
 }


### PR DESCRIPTION
Improves the doc coverage for ratelimiter. Fixes the example so
there is a pause between last loop iteration and final print.
