### PR TITLE
datastructures: fix clippy warnings

### DIFF
--- a/datastructures/src/buffer/mod.rs
+++ b/datastructures/src/buffer/mod.rs
@@ -77,6 +77,20 @@ where
         self.len.load(Ordering::SeqCst)
     }
 
+    /// Returns true if the buffer is empty
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datastructures::*;
+    ///
+    /// let x = Buffer::<AtomicU8>::new(4096);
+    /// assert!(x.is_empty())
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len.load(Ordering::SeqCst) == 0
+    }
+
     /// Tries to return one element from the buffer
     /// Returns Ok(None) if the buffer is empty
     /// Returns Ok(Some(T)) if we were able to read a value

--- a/datastructures/src/histogram/mod.rs
+++ b/datastructures/src/histogram/mod.rs
@@ -11,6 +11,8 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+type SharedVecDeque<T> = Arc<Mutex<VecDeque<T>>>;
+
 /// `Histogram` is inspired by HDRHistogram and stores a counter for `Bucket`s
 /// across a range of input values. `Histogram`s store between 0 and the `max`
 /// value passed to the constructor. Optionally, a `Histogram` may retain
@@ -32,7 +34,7 @@ where
     index: Vec<AtomicU64>,
     too_high: AtomicU64,
     precision: AtomicU32,
-    samples: Option<Arc<Mutex<VecDeque<Sample<<T as AtomicPrimitive>::Primitive>>>>>,
+    samples: Option<SharedVecDeque<Sample<<T as AtomicPrimitive>::Primitive>>>,
     window: Option<Arc<Mutex<Duration>>>,
     capacity: Option<AtomicUsize>,
 }


### PR DESCRIPTION
Fixes clippy warnings in the datastructures crate