### PR TITLE
atomics: fix clippy warnings

### DIFF
--- a/atomics/src/atomic_option/mod.rs
+++ b/atomics/src/atomic_option/mod.rs
@@ -283,11 +283,7 @@ where
                 false
             }
         } else {
-            if other.is_some.load(Ordering::SeqCst) {
-                false
-            } else {
-                true
-            }
+            !other.is_some.load(Ordering::SeqCst)
         }
     }
 }
@@ -340,7 +336,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        T::deserialize(deserializer).map(|v| AtomicOption::some(v))
+        T::deserialize(deserializer).map(AtomicOption::some)
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_bool.rs
+++ b/atomics/src/atomic_primitive/atomic_bool.rs
@@ -107,7 +107,7 @@ impl<'de> Visitor<'de> for AtomicBoolVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(AtomicBool::new(bool::from(value)))
+        Ok(AtomicBool::new(value))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_i16.rs
+++ b/atomics/src/atomic_primitive/atomic_i16.rs
@@ -114,7 +114,7 @@ impl<'de> Visitor<'de> for AtomicI16Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(i16::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_i32<E>(self, value: i32) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_i32.rs
+++ b/atomics/src/atomic_primitive/atomic_i32.rs
@@ -121,7 +121,7 @@ impl<'de> Visitor<'de> for AtomicI32Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(i32::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_i64.rs
+++ b/atomics/src/atomic_primitive/atomic_i64.rs
@@ -128,7 +128,7 @@ impl<'de> Visitor<'de> for AtomicI64Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(i64::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_i8.rs
+++ b/atomics/src/atomic_primitive/atomic_i8.rs
@@ -107,7 +107,7 @@ impl<'de> Visitor<'de> for AtomicI8Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(i8::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_u16.rs
+++ b/atomics/src/atomic_primitive/atomic_u16.rs
@@ -162,7 +162,7 @@ impl<'de> Visitor<'de> for AtomicU16Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(u16::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_u32.rs
+++ b/atomics/src/atomic_primitive/atomic_u32.rs
@@ -169,7 +169,7 @@ impl<'de> Visitor<'de> for AtomicU32Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(u32::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>

--- a/atomics/src/atomic_primitive/atomic_u64.rs
+++ b/atomics/src/atomic_primitive/atomic_u64.rs
@@ -176,7 +176,7 @@ impl<'de> Visitor<'de> for AtomicU64Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(u64::from(value)))
+        Ok(Self::Value::new(value))
     }
 }
 

--- a/atomics/src/atomic_primitive/atomic_u8.rs
+++ b/atomics/src/atomic_primitive/atomic_u8.rs
@@ -155,7 +155,7 @@ impl<'de> Visitor<'de> for AtomicU8Visitor {
     where
         E: serde::de::Error,
     {
-        Ok(Self::Value::new(u8::from(value)))
+        Ok(Self::Value::new(value))
     }
 
     fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>


### PR DESCRIPTION
Fixes clippy warnings throughout the atomics crate