### PR TITLE
metrics: add check before deleting channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "datastructures 0.4.0",
  "logger 0.1.0",
- "metrics 0.4.0",
+ "metrics 0.4.1",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "datastructures 0.4.0",
  "evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -864,7 +864,7 @@ dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "datastructures 0.4.0",
  "logger 0.1.0",
- "metrics 0.4.0",
+ "metrics 0.4.1",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimiter 0.3.1",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/metrics/src/metrics/mod.rs
+++ b/metrics/src/metrics/mod.rs
@@ -97,11 +97,18 @@ where
 
     pub fn delete_channel(&self, name: String) {
         debug!("delete channel: {}", name);
-        let mut write = self.write.lock().unwrap();
-        write.empty(name.clone());
-        write.refresh();
-        let mut labels = self.labels.lock().unwrap();
-        labels.remove(&name);
+        if self
+            .read
+            .get_and(&name, |channel| channel.len())
+            .unwrap_or(0)
+            != 0
+        {
+            let mut write = self.write.lock().unwrap();
+            write.empty(name.clone());
+            write.refresh();
+            let mut labels = self.labels.lock().unwrap();
+            labels.remove(&name);
+        }
     }
 
     pub fn readings(&self) -> Vec<Reading> {


### PR DESCRIPTION
Adds a check for the existence of a metrics channel before taking
the lock and removing it. This avoids unnecessary locking.

Fixes #262

Problem

Currently we optimistically take a lock on the metrics registry and
remove the channel. This causes unnecessary locking when the 
channel does not exist.

Solution

Adds a check for the existence of the channel before locking and trying
to remove it.

Result

Users of the library will not need to handle tracking whether a channel is
already removed if they wish to avoid the lock.
