### PR TITLE
Metrics facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,15 +23,15 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -43,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "atomics"
 version = "0.3.0"
 dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -51,33 +51,33 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.38"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -101,7 +101,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,16 +133,15 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "c2-chacha"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -152,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -165,7 +164,7 @@ name = "chrono"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -183,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -195,7 +194,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -238,17 +237,41 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -261,7 +284,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -278,11 +310,11 @@ name = "crossbeam-epoch"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -311,8 +343,8 @@ dependencies = [
  "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,30 +386,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "evmap"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -390,7 +422,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -401,11 +433,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "getrandom"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -414,7 +446,15 @@ name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -442,16 +482,15 @@ dependencies = [
 
 [[package]]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -464,10 +503,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -486,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -519,16 +558,21 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,8 +583,20 @@ name = "metrics"
 version = "0.4.0"
 dependencies = [
  "datastructures 0.4.0",
- "evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evmap 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metrics-core"
+version = "0.1.0"
+dependencies = [
+ "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evmap 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -551,9 +607,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -578,13 +634,13 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nodrop"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -601,7 +657,7 @@ name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -610,16 +666,22 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ordered-float"
@@ -646,10 +708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -663,7 +725,7 @@ name = "png"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,20 +733,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -692,18 +746,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -711,8 +757,8 @@ name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -723,7 +769,7 @@ name = "rand_chacha"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -745,7 +791,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -771,10 +817,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -784,6 +839,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,7 +876,7 @@ dependencies = [
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -842,12 +905,12 @@ name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -869,13 +932,13 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratelimiter 0.3.1",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "timer 0.1.2",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterfall 0.4.0",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -911,14 +974,14 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -958,17 +1021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -977,8 +1040,8 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -988,8 +1051,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.10"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sourcefile"
@@ -1016,33 +1082,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.10.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1054,11 +1110,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1087,16 +1151,16 @@ name = "tinytemplate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1112,22 +1176,17 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1177,65 +1236,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen-webidl"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1257,14 +1316,14 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-webidl 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1334,23 +1393,23 @@ dependencies = [
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-"checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum arrayvec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead801bcb8843bc91ea0a028f95b786f39ce519b1738de4e74a2a393332c2a16"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
-"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
+"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
@@ -1359,7 +1418,9 @@ dependencies = [
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
+"checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
+"checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
@@ -1369,46 +1430,47 @@ dependencies = [
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "017b75b5fbc5806d490da36acc5c4d0e4ae1b69890d02f24c268da971813fbc1"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e08ace17a9241686f923cb5707822823a6e36f36796eb87035d77c158867ab3"
-"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum evmap 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f66c81fcd6d1a1efc04b4b06d4ba4d0bc3c51708c8c8a72060bd12887e62793"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "575fb7f1167f3b88ed825e90eb14918ac460461fdeaa3965c6a50951dee1c970"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc9a97d7cec30128fd8b28a7c1f9df1c001ceb9b441e2b755e24130a6b43c79"
+"checksum js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "a60f6ca5eb7ae3014e3ab34e3189a1560267245216e19f76a021a4c669817e62"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
+"checksum memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a85c1a8c329f11437034d7313dca647c79096523533a1c79e86f1d0f657c7cc"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8422b27bb2c013dd97b9aef69e161ce262236f49aaf46a0489011c8ff0264602"
-"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
@@ -1418,7 +1480,9 @@ dependencies = [
 "checksum rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 "checksum rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03b418169fb9c46533f326efd6eed2576699c44ca92d3052a066214a8d828929"
+"checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -1429,34 +1493,33 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa38506b5cbf2fb67f915e2725cb5012f1b9a785b0ab55c4733acda5f6554ef"
-"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
-"checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
+"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
+"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stb_truetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "824210d6fb52cbc3ad2545270ead6860c7311aa5450642b078da4515937b6f7a"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
-"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+"checksum synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "575be94ccb86e8da37efb894a87e2b660be299b41d8ef347f9d6d79fbe61b1ba"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thread_local 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88ddf1ad580c7e3d1efff877d972bcc93f995556b9087a5a259630985c88ceab"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
-"checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
+"checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+"checksum unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
@@ -1464,13 +1527,13 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum wasm-bindgen 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "cd34c5ba0d228317ce388e87724633c57edca3e7531feb4e25e35aaa07a656af"
-"checksum wasm-bindgen-backend 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "927196b315c23eed2748442ba675a4c54a1a079d90d9bdc5ad16ce31cf90b15b"
-"checksum wasm-bindgen-macro 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "92c2442bf04d89792816650820c3fb407af8da987a9f10028d5317f5b04c2b4a"
-"checksum wasm-bindgen-macro-support 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "9c075d27b7991c68ca0f77fe628c3513e64f8c477d422b859e03f28751b46fc5"
-"checksum wasm-bindgen-shared 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "83d61fe986a7af038dd8b5ec660e5849cbd9f38e7492b9404cc48b2b4df731d1"
-"checksum wasm-bindgen-webidl 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "9b979afb0535fe4749906a674082db1211de8aef466331d43232f63accb7c07c"
-"checksum web-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "c84440699cd02ca23bed6f045ffb1497bc18a3c2628bd13e2093186faaaacf6b"
+"checksum wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "4c29d57d5c3b3bc53bbe35c5a4f4a0df994d870b7d3cb0ad1c2065e21822ae41"
+"checksum wasm-bindgen-backend 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "aa2868fa93e5bf36a9364d1277a0f97392748a8217d9aa0ec3f1cdbdf7ad1a60"
+"checksum wasm-bindgen-macro 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "41e80594782a241bf3d92ee5d1247b8fb496250a8a2ff1e136942d433fbbce14"
+"checksum wasm-bindgen-macro-support 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "74b9950355b1d92ca09de0984bdd4de7edda5e8af12daf0c052a0a075e8c9157"
+"checksum wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7493fe67ad99672ef3de3e6ba513fb03db276358c8cc9588ce5a008c6e48ad68"
+"checksum wasm-bindgen-webidl 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "8272d9a8831be66b30908996b71b3eaf9b83de050f89e4dc34826a19980eb59d"
+"checksum web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0232f38e5c66384edaedaa726ae2d6313e3ed3ae860693c497a3193af3e161ce"
 "checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "datastructures",
     "logger",
     "metrics",
+    "metrics-core",
     "ratelimiter",
     "rpc-perf",
     "timer",

--- a/metrics-core/Cargo.toml
+++ b/metrics-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "metrics-core"
+version = "0.1.0"
+authors = ["Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "Metrics facade"
+publish = false
+
+[dependencies]
+evmap = "7.1.0"
+time = "0.1.42"
+thread_local = "1.0.0"
+once_cell = "1.2.0"
+log = "0.4.8"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benches"
+harness = false

--- a/metrics-core/benches/benches.rs
+++ b/metrics-core/benches/benches.rs
@@ -1,0 +1,128 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use metrics_core::*;
+
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn thread_id(bencher: &mut Bencher) {
+    bencher.iter(|| std::thread::current().id())
+}
+
+struct AtomicCounter {
+    ctr: AtomicU64,
+}
+
+impl AtomicCounter {
+    pub fn new() -> Self {
+        Self {
+            ctr: AtomicU64::new(0),
+        }
+    }
+}
+
+impl MetricCommon for AtomicCounter {}
+
+impl Counter for AtomicCounter {
+    fn store(&self, _: Instant, val: u64) {
+        self.ctr.store(val, Ordering::Relaxed);
+    }
+
+    fn load(&self) -> u64 {
+        self.ctr.load(Ordering::Relaxed)
+    }
+
+    fn add(&self, _: Instant, amount: u64) {
+        self.ctr.fetch_add(amount, Ordering::Relaxed);
+    }
+}
+
+struct Noop;
+
+impl MetricCommon for Noop {}
+impl Counter for Noop {
+    fn store(&self, _: Instant, _: u64) {}
+    fn load(&self) -> u64 {
+        0
+    }
+    fn add(&self, _: Instant, _: u64) {}
+}
+
+fn increment_counter(bench: &mut Bencher) {
+    let counter = AtomicCounter::new();
+    let _scoped =
+        unsafe { ScopedMetric::counter("test.metric", &counter, Metadata::empty()).unwrap() };
+
+    bench.iter(|| {
+        increment!("test.metric", MetricValue::Unsigned(10));
+    })
+}
+
+fn set_noop_metric(bench: &mut Bencher) {
+    let counter = Noop;
+    let _scoped =
+        unsafe { ScopedMetric::counter("test.noop", &counter, Metadata::empty()).unwrap() };
+
+    bench.iter(|| {
+        value!("test.noop", MetricValue::Unsigned(56));
+    })
+}
+
+fn noop_metric_external_counter(bench: &mut Bencher) {
+    let counter = Noop;
+    let _scoped = unsafe {
+        ScopedMetric::counter("test.noop.external-time", &counter, Metadata::empty()).unwrap()
+    };
+
+    let time = Instant::now();
+
+    bench.iter(|| {
+        value!(
+            "test.noop.external-time",
+            MetricValue::Unsigned(56),
+            time = time
+        )
+    })
+}
+
+fn atomic_add(b: &mut Bencher) {
+    let ctr = AtomicU64::new(0);
+
+    b.iter(|| ctr.fetch_add(37, Ordering::Relaxed));
+}
+
+fn mutex_lock(b: &mut Bencher) {
+    let mutex = std::sync::Mutex::new(());
+
+    b.iter(|| mutex.lock());
+}
+
+fn current_time(b: &mut Bencher) {
+    b.iter(|| Instant::now());
+}
+
+fn std_current_time(b: &mut Bencher) {
+    b.iter(|| std::time::Instant::now());
+}
+
+fn bench_all(b: &mut Criterion) {
+    b.bench_function("mutex_lock", mutex_lock);
+    b.bench_function("atomic_add", atomic_add);
+    b.bench_function("thread_id", thread_id);
+    b.bench_function("current_time", current_time);
+    b.bench_function("std_current_time", std_current_time);
+    b.bench_function("set_noop_metric", set_noop_metric);
+    b.bench_function("increment_counter", increment_counter);
+    b.bench_function("noop_metric_external_counter", noop_metric_external_counter);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_all
+);
+
+criterion_main!(benches);

--- a/metrics-core/src/dyncow.rs
+++ b/metrics-core/src/dyncow.rs
@@ -1,0 +1,128 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::ops::Deref;
+
+use evmap::ShallowCopy;
+
+use crate::{Counter, Gauge, Summary};
+
+/// Analog to [`Cow`][stdcow] but for specific trait objects.
+///
+/// This allows for either storing a dynamic reference to a trait or a boxed
+/// trait. However, it doesn't support most of the options that [`Cow`][stdcow]
+/// supports since we are unable to promote a dyn trait reference to a boxed
+/// trait.
+///
+/// [stdcow]: std::borrow::Cow
+pub enum DynCow<'a, T: ?Sized> {
+    /// A reference to a T
+    Borrowed(&'a T),
+    /// An owned box containing a T
+    Owned(Box<T>),
+}
+
+impl<'a, T: ?Sized> DynCow<'a, T> {
+    /// Create a `DynCow` from a pointer.
+    ///
+    /// # Safety
+    /// For this to be safe `ptr` must be a pointer to a valid instance of a `T`
+    /// and it must outlive the resulting `DynCow` instance.
+    pub unsafe fn from_ptr(ptr: *const T) -> Self {
+        Self::Borrowed(&*ptr)
+    }
+
+    /// Get a pointer pointing to the instance stored within this `DynCow`.
+    pub fn as_ptr(&self) -> *const T {
+        &**self as *const T
+    }
+}
+
+impl<'a, T: ?Sized> Deref for DynCow<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            Self::Borrowed(x) => x,
+            Self::Owned(x) => &*x,
+        }
+    }
+}
+
+impl<'a, T: ?Sized> From<&'a T> for DynCow<'a, T> {
+    fn from(val: &'a T) -> Self {
+        Self::Borrowed(val)
+    }
+}
+
+impl<'a, H> From<Box<H>> for DynCow<'a, dyn Summary + 'a>
+where
+    H: Summary + 'a,
+{
+    fn from(val: Box<H>) -> Self {
+        Self::Owned(val)
+    }
+}
+
+impl<'a, C> From<Box<C>> for DynCow<'a, dyn Counter + 'a>
+where
+    C: Counter + 'a,
+{
+    fn from(val: Box<C>) -> Self {
+        Self::Owned(val)
+    }
+}
+
+impl<'a, G> From<Box<G>> for DynCow<'a, dyn Gauge + 'a>
+where
+    G: Gauge + 'a,
+{
+    fn from(val: Box<G>) -> Self {
+        Self::Owned(val)
+    }
+}
+
+impl<'a, H> From<&'a H> for DynCow<'a, dyn Summary + 'a>
+where
+    H: Summary + 'a,
+{
+    fn from(val: &'a H) -> Self {
+        Self::Borrowed(val)
+    }
+}
+
+impl<'a, C> From<&'a C> for DynCow<'a, dyn Counter + 'a>
+where
+    C: Counter + 'a,
+{
+    fn from(val: &'a C) -> Self {
+        Self::Borrowed(val)
+    }
+}
+
+impl<'a, G> From<&'a G> for DynCow<'a, dyn Gauge + 'a>
+where
+    G: Gauge + 'a,
+{
+    fn from(val: &'a G) -> Self {
+        Self::Borrowed(val)
+    }
+}
+
+impl<'a, T: ?Sized> PartialEq for DynCow<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ptr() == other.as_ptr()
+    }
+}
+
+impl<'a, T: ?Sized> Eq for DynCow<'a, T> {}
+
+impl<'a, T: ?Sized> ShallowCopy for DynCow<'a, T> {
+    unsafe fn shallow_copy(&mut self) -> Self {
+        match self {
+            Self::Borrowed(x) => Self::Borrowed(x),
+            Self::Owned(b) => Self::Owned(b.shallow_copy()),
+        }
+    }
+}

--- a/metrics-core/src/error.rs
+++ b/metrics-core/src/error.rs
@@ -1,0 +1,251 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::error::Error;
+use std::fmt;
+
+use crate::MetricType;
+
+#[doc(hidden)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Empty {}
+
+/// Error for when a summary is unable to produce
+/// submetrics or buckets.
+///
+/// This enum should not be matched exhaustively. However, if for testing
+/// purposes it is desired to match exhaustively, that can be done by matching
+/// the final variant like this
+/// ```rust
+/// # use metrics_core::*;
+/// # let data = RegisterError::MetricAlreadyExists;
+/// match data {
+///     // ...
+///     RegisterError::__Nonexhaustive(empty) => match empty { },
+/// #   _ => ()
+/// }
+/// ```
+///
+/// Note, however, that no semver guarantees are given for doing this so
+/// any new version of metrics-core could break the above code.
+#[derive(Debug)]
+pub enum SummaryError {
+    /// The summary doesn't support the requested metric type
+    Unsupported,
+    /// Custom error type
+    Custom(Box<dyn Error>),
+
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+/// Error for when registering a metric fails.
+///
+/// This enum should not be matched exhaustively. However, if for testing
+/// purposes it is desired to match exhaustively, that can be done by matching
+/// the final variant like this
+/// ```rust
+/// # use metrics_core::*;
+/// # let data = RegisterError::MetricAlreadyExists;
+/// match data {
+///     // ...
+///     RegisterError::__Nonexhaustive(empty) => match empty { },
+/// #   _ => ()
+/// }
+/// ```
+///
+/// Note, however, that no semver guarantees are given for doing this so
+/// any new version of metrics-core could break the above code.
+#[derive(Copy, Clone, Debug)]
+pub enum RegisterError {
+    /// A metric has already been registered under that name
+    MetricAlreadyExists,
+    /// The metrics library has been shut down
+    LibraryShutdown,
+
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+/// Error for when unregistering a metric fails.
+///
+/// This enum should not be matched exhaustively. However, if for testing
+/// purposes it is desired to match exhaustively, that can be done by matching
+/// the final variant like this
+/// ```rust
+/// # use metrics_core::*;
+/// # let data = UnregisterError::NoSuchMetric;
+/// match data {
+///     // ...
+///     UnregisterError::__Nonexhaustive(empty) => match empty { },
+/// #   _ => ()
+/// }
+/// ```
+///
+/// Note, however, that no semver guarantees are given for doing this so
+/// any new version of metrics-core could break the above code.
+#[derive(Copy, Clone, Debug)]
+pub enum UnregisterError {
+    /// There is no metric with that name to remove
+    NoSuchMetric,
+    /// The metrics library has been shut down
+    LibraryShutdown,
+
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+/// Description of why writing to a metric failed.
+///
+/// This enum should not be matched exhaustively. However, if for testing
+/// purposes it is desired to match exhaustively, that can be done by matching
+/// the final variant like this
+/// ```rust
+/// # use metrics_core::*;
+/// # let data = MetricErrorData::InvalidUnsignedValue(0);
+/// match data {
+///     // ...
+///     MetricErrorData::__Nonexhaustive(empty) => match empty { },
+/// #   _ => ()
+/// }
+/// ```
+///
+/// Note, however, that no semver guarantees are given for doing this so
+/// any new version of metrics-core could break the above code.
+#[derive(Copy, Clone, Debug)]
+pub enum MetricErrorData {
+    /// Tried to pass a signed value that was negative to something expecting an
+    /// unsigned value.
+    InvalidUnsignedValue(i64),
+    /// Tried to pass an unsigned value that was too large to something
+    /// expecting a signed value.
+    InvalidSignedValue(u64),
+    /// The metric is not a type of metric that can be incremented (it's a
+    /// histogram)
+    InvalidIncrement {
+        /// The type of metric we attempted to increment.
+        ty: MetricType,
+    },
+    /// The metric is not a type of metric that can be decremented (it's either
+    /// a histogram or a counter)
+    InvalidDecrement {
+        /// The type of metric we attempted to decrement
+        ty: MetricType,
+    },
+    /// Tried to perform an operation that expected one type but instead we got
+    /// another type.
+    WrongType {
+        /// The type of metric that we expected to find.
+        expected: MetricType,
+        /// What was actually found.
+        found: MetricType,
+    },
+
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+/// An error for when writing to a metric failed.
+#[derive(Copy, Clone, Debug)]
+pub struct MetricError<'m> {
+    /// The metric that was being written to.
+    pub metric: &'m str,
+    /// Details on what exactly the problem was
+    pub data: MetricErrorData,
+}
+
+impl<'m> MetricError<'m> {
+    pub(crate) fn invalid_unsigned(metric: &'m str, val: i64) -> Self {
+        Self {
+            metric,
+            data: MetricErrorData::InvalidUnsignedValue(val),
+        }
+    }
+
+    pub(crate) fn invalid_signed(metric: &'m str, val: u64) -> Self {
+        Self {
+            metric,
+            data: MetricErrorData::InvalidSignedValue(val),
+        }
+    }
+
+    pub(crate) fn invalid_increment(metric: &'m str, ty: MetricType) -> Self {
+        Self {
+            metric,
+            data: MetricErrorData::InvalidIncrement { ty },
+        }
+    }
+
+    pub(crate) fn invalid_decrement(metric: &'m str, ty: MetricType) -> Self {
+        Self {
+            metric,
+            data: MetricErrorData::InvalidDecrement { ty },
+        }
+    }
+
+    pub(crate) fn wrong_type(metric: &'m str, expected: MetricType, found: MetricType) -> Self {
+        Self {
+            metric,
+            data: MetricErrorData::WrongType { expected, found },
+        }
+    }
+}
+
+impl<'m> fmt::Display for MetricError<'m> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use self::MetricErrorData::*;
+
+        match &self.data {
+            InvalidUnsignedValue(val) => write!(
+                fmt,
+                r#"Attempted to write a value '{}' to the metric '{}' \
+                     but it could not be converted to a u64"#,
+                val, self.metric
+            ),
+            InvalidSignedValue(val) => write!(
+                fmt,
+                r#"Attempted to write a value '{}' to the metric '{}' \
+                       but it could not be converted to a i64"#,
+                val, self.metric
+            ),
+            InvalidIncrement { ty } => write!(
+                fmt,
+                r#"Attempted to increment metric '{}' but it \
+                       is a {} which does not support being incremented"#,
+                self.metric, ty
+            ),
+            InvalidDecrement { ty } => write!(
+                fmt,
+                r#"Attempted to decrement metric '{}' but it \
+                       is a {} which does not support being decrement"#,
+                self.metric, ty
+            ),
+            WrongType { expected, found } => write!(
+                fmt,
+                "Expected metric '{}' to be a {} but it was actually a {}",
+                self.metric, expected, found
+            ),
+
+            &__Nonexhaustive(e) => match e {},
+        }
+    }
+}
+
+impl<'m> Error for MetricError<'m> {}
+
+impl fmt::Display for SummaryError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Unsupported => fmt.write_str("operation not supported"),
+            Self::Custom(err) => err.fmt(fmt),
+            &Self::__Nonexhaustive(empty) => match empty {},
+        }
+    }
+}
+
+impl From<Box<dyn Error>> for SummaryError {
+    fn from(err: Box<dyn Error>) -> Self {
+        Self::Custom(err)
+    }
+}

--- a/metrics-core/src/inner.rs
+++ b/metrics-core/src/inner.rs
@@ -1,0 +1,142 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::any::Any;
+
+use evmap::ShallowCopy;
+
+use crate::{Counter, DynCow, Gauge, Metadata, MetricCommon, Summary};
+
+/// The type of a metric.
+///
+/// This is provided for convenience but usually you'll want to match on
+/// [`Metric`][metric].
+///
+/// [metric]: crate::Metric
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MetricType {
+    Counter,
+    Gauge,
+    Summary,
+}
+
+impl std::fmt::Display for MetricType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Counter => write!(fmt, "counter"),
+            Self::Gauge => write!(fmt, "gauge"),
+            Self::Summary => write!(fmt, "summary"),
+        }
+    }
+}
+
+/// A stored metric. Used for introspection.
+#[allow(missing_docs)]
+#[derive(Eq, PartialEq)]
+pub enum Metric {
+    Counter(DynCow<'static, dyn Counter>),
+    Gauge(DynCow<'static, dyn Gauge>),
+    Summary(DynCow<'static, dyn Summary>),
+}
+
+impl Metric {
+    /// The type of the metric.
+    pub fn ty(&self) -> MetricType {
+        match self {
+            Self::Counter(_) => MetricType::Counter,
+            Self::Gauge(_) => MetricType::Gauge,
+            Self::Summary(_) => MetricType::Summary,
+        }
+    }
+}
+
+/// A metric and its metadata.
+#[derive(Eq, PartialEq)]
+pub struct MetricInstance {
+    pub(crate) inner: Metric,
+    pub(crate) metadata: Metadata,
+}
+
+impl MetricInstance {
+    pub(crate) fn new(metric: Metric, metadata: Metadata) -> Self {
+        Self {
+            inner: metric,
+            metadata,
+        }
+    }
+
+    /// The type of this metric.
+    pub fn ty(&self) -> MetricType {
+        self.inner.ty()
+    }
+
+    /// The metadata associated with this metric.
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// The current metric as a MetricCommon instance.
+    pub fn as_metric(&self) -> &dyn MetricCommon {
+        self.metric()
+    }
+
+    /// The inner type containing the actual metrics.
+    pub fn metric(&self) -> &Metric {
+        &self.inner
+    }
+
+    /// If this type is a counter, get a reference to that counter.
+    pub fn as_counter(&self) -> Option<&dyn Counter> {
+        match self.metric() {
+            Metric::Counter(c) => Some(&**c),
+            _ => None,
+        }
+    }
+
+    /// If this type is a gauge, get a reference to that gauge.
+    pub fn as_gauge(&self) -> Option<&dyn Gauge> {
+        match self.metric() {
+            Metric::Gauge(g) => Some(&**g),
+            _ => None,
+        }
+    }
+
+    /// If this type is a summary, get a reference to that summary.
+    pub fn as_summary(&self) -> Option<&dyn Summary> {
+        match self.metric() {
+            Metric::Summary(h) => Some(&**h),
+            _ => None,
+        }
+    }
+}
+
+impl MetricCommon for Metric {
+    fn as_any(&self) -> Option<&dyn Any> {
+        match self {
+            Self::Counter(c) => c.as_any(),
+            Self::Gauge(g) => g.as_any(),
+            Self::Summary(h) => h.as_any(),
+        }
+    }
+}
+
+impl ShallowCopy for MetricInstance {
+    unsafe fn shallow_copy(&mut self) -> Self {
+        Self {
+            inner: self.inner.shallow_copy(),
+            metadata: self.metadata,
+        }
+    }
+}
+
+impl ShallowCopy for Metric {
+    unsafe fn shallow_copy(&mut self) -> Self {
+        match self {
+            Self::Counter(x) => Self::Counter(x.shallow_copy()),
+            Self::Gauge(x) => Self::Gauge(x.shallow_copy()),
+            Self::Summary(x) => Self::Summary(x.shallow_copy()),
+        }
+    }
+}

--- a/metrics-core/src/instant.rs
+++ b/metrics-core/src/instant.rs
@@ -1,0 +1,118 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::ops::Sub;
+
+use time;
+
+/// High-resolution timestamp.
+///
+/// This timestamp behaves in most respects like
+/// [`std::time::Instant`](std::time::Instant). However, when subtracting two
+/// instants `A - B` it will return a duration of zero when `A` is before `B`.
+#[derive(Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Instant {
+    // Our representation is the number of nanoseconds since an unspecified
+    // (but consistent within the process) epoch. For more details see the docs
+    // for the time crate.
+    //
+    // In practice this is the return value of `time::precise_time_ns`
+    ns_since_epoch: u64,
+}
+
+impl Instant {
+    /// Get the current time
+    pub fn now() -> Self {
+        Instant {
+            ns_since_epoch: time::precise_time_ns(),
+        }
+    }
+}
+
+/// Timespan between two instance.
+///
+/// Similar to [`std::time::Duration`](std::time::Duration).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Interval {
+    duration_ns: u64,
+}
+
+impl Interval {
+    /// Convert a number of seconds to an interval.
+    ///
+    /// Saturates to the maximum value if secs is more than `u64::MAX`
+    /// nanoseconds.
+    pub fn from_seconds(secs: u64) -> Self {
+        Self {
+            duration_ns: secs.saturating_mul(1_000_000_000),
+        }
+    }
+
+    /// Convert a number of milliseconds to an interval.
+    ///
+    /// Saturates to the maximum value if secs is more than `u64::MAX`
+    /// nanoseconds.
+    pub fn from_millis(millis: u64) -> Self {
+        Self {
+            duration_ns: millis.saturating_mul(1_000_000),
+        }
+    }
+
+    /// Convert a number of microseconds to an interval.
+    ///
+    /// Saturates to the maximum value if secs is more than `u64::MAX`
+    /// nanoseconds.
+    pub fn from_micros(micros: u64) -> Self {
+        Self {
+            duration_ns: micros.saturating_mul(1_000),
+        }
+    }
+
+    /// Convert a number of nanoseconds to an interval.
+    pub fn from_nanos(nanos: u64) -> Self {
+        Self { duration_ns: nanos }
+    }
+
+    /// Get number of seconds in the current interval.
+    ///
+    /// Truncates towards zero.
+    pub fn as_seconds(self) -> u64 {
+        self.duration_ns / 1_000_000_000
+    }
+
+    /// Get number of milliseconds in the current interval.
+    ///
+    /// Truncates towards zero.
+    pub fn as_millis(self) -> u64 {
+        self.duration_ns / 1_000_000
+    }
+
+    /// Get number of microseconds in the current interval.
+    ///
+    /// Truncates towards zero.
+    pub fn as_micros(self) -> u64 {
+        self.duration_ns / 1_000
+    }
+
+    /// Get number of nanoseconds in the current interval.
+    pub fn as_nanos(self) -> u64 {
+        self.duration_ns
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Interval;
+
+    fn sub(self, other: Instant) -> Interval {
+        Interval {
+            duration_ns: self.ns_since_epoch.saturating_sub(other.ns_since_epoch),
+        }
+    }
+}
+
+impl From<Interval> for crate::MetricValue {
+    fn from(intvl: Interval) -> Self {
+        Self::Unsigned(intvl.as_nanos())
+    }
+}

--- a/metrics-core/src/lib.rs
+++ b/metrics-core/src/lib.rs
@@ -1,0 +1,261 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+//! Metrics facade that allows for using multiple metrics backends.
+//!
+//! Metrics types should implement one of [`Counter`][counter],
+//! [`Gauge`][gauge], or [`Summary`][summary]. Then they can be registered
+//! through one of [`register_counter`][rctr], [`register_gauge`][rgauge], or
+//! [`register_summary`][rhist] functions.
+//!
+//! # Metadata
+//! Each individual metric can have metadata associated with. This is a set of
+//! static key-value pairs that can be used to store arbitrary properties of the
+//! metric. Empty metadata can be created by calling
+//! [`Metadata::new`](Metadata::new). Otherwise, `Metadata` is created using the
+//! `metadata` macro.
+//!
+//! # Introspection
+//! To examine and query metrics, use the [`for_each_metric`][for_each_metric]
+//! function.
+//!
+//! # Error Handling
+//! This library has a somewhat idiosyncratic approach to error handling.
+//! Instead of returning a result from each metric function/macro there
+//! is a global error handling function (set by [`set_error_fn`](set_error_fn))
+//! which is called with the error whenever an invalid action is performed.
+//!
+//! **Important Note:** attempting to record values to a non-existent metric
+//! is not considered an error for performance reasons.
+//!
+//! # Example
+//! ```rust
+//! # use metrics_core::*;
+//! # struct Metric;
+//! # impl MetricCommon for Metric {}
+//! # impl Summary for Metric {
+//! #   fn record(&self, time: Instant, val: u64, count: u64) {}
+//! #   fn submetrics(&self) -> Result<Vec<SubMetric>, SummaryError> { Ok(vec![]) }
+//! #   fn quantiles(&self, q: &[Percentile], out: &mut [u64]) -> Result<(), SummaryError> { unimplemented!() }
+//! #   fn buckets(&self) -> Result<Vec<Bucket>, SummaryError> { unimplemented!() }
+//! # }
+//! # fn function_that_takes_some_time() {}
+//! // Create a metric named "example.metric" with no associated metadata
+//! register_summary("example.metric", Box::new(Metric), Metadata::empty());
+//!
+//! // Alternatively, we can add metadata using the metadata! macro.
+//! register_summary(
+//!     "example.metadata",
+//!     Box::new(Metric),
+//!     metadata! {
+//!         "some key" => "some value",
+//!         "unit" => "ns"
+//!     }
+//! );
+//!
+//! // If you have a static reference to a metric, then you can avoid boxing it
+//! static METRIC_INSTANCE: Metric = Metric;
+//! register_summary(
+//!     "example.static",
+//!     &METRIC_INSTANCE,
+//!     Metadata::empty()
+//! );
+//!
+//! // Now we can use these metrics like so
+//!
+//! // Record single values to "example.metric"
+//! value!("example.metric", 10);
+//! value!("example.metric", 11);
+//!
+//! // Record a value and a count, note that the count
+//! // is only used by summarys.
+//! value!("example.static", 120, 44);
+//!
+//! // Can also record timings
+//! let start = Instant::now();
+//! function_that_takes_some_time();
+//! let end = Instant::now();
+//! // This gets translated to a duration in nanoseconds
+//! interval!("example.metadata", start, end);
+//! ```
+//!
+//! [counter]: crate::Counter
+//! [gauge]: crate::Gauge
+//! [summary]: crate::Summary
+//! [rctr]: crate::register_counter
+//! [rgauge]: crate::register_gauge
+//! [rhist]: crate::register_summary
+//! [for_each_metric]: crate::for_each_metric
+
+#![warn(intra_doc_link_resolution_failure, missing_docs)]
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate log;
+
+#[macro_use]
+mod macros;
+
+mod dyncow;
+mod error;
+mod inner;
+mod instant;
+mod metadata;
+mod percentile;
+mod scoped;
+mod state;
+mod submetric;
+mod traits;
+mod value;
+
+pub use crate::dyncow::DynCow;
+pub use crate::error::{
+    MetricError, MetricErrorData, RegisterError, SummaryError, UnregisterError,
+};
+pub use crate::inner::{Metric, MetricInstance, MetricType};
+pub use crate::instant::{Instant, Interval};
+pub use crate::metadata::Metadata;
+pub use crate::percentile::Percentile;
+pub use crate::scoped::ScopedMetric;
+pub use crate::submetric::{Bucket, SubMetric, SubMetricValue};
+pub use crate::traits::{Counter, Gauge, MetricCommon, Summary};
+pub use crate::value::MetricValue;
+
+use std::borrow::Cow;
+
+use crate::state::State;
+
+/// Register a new counter.
+///
+/// If a metric has already been registered under the same name, then it will
+/// return an error.
+pub fn register_counter(
+    name: impl Into<Cow<'static, str>>,
+    counter: impl Into<DynCow<'static, dyn Counter>>,
+    metadata: Metadata,
+) -> Result<(), RegisterError> {
+    State::get_force().register_metric(name.into(), Metric::Counter(counter.into()), metadata)
+}
+
+/// Register a new gauge.
+///
+/// If a metric has already been registered under the same name, then it will
+/// return an error.
+pub fn register_gauge(
+    name: impl Into<Cow<'static, str>>,
+    gauge: impl Into<DynCow<'static, dyn Gauge>>,
+    metadata: Metadata,
+) -> Result<(), RegisterError> {
+    State::get_force().register_metric(name.into(), Metric::Gauge(gauge.into()), metadata)
+}
+
+/// Register a new summary.
+///
+/// If a metric has already been registered under the same name, then it will
+/// return an error.
+pub fn register_summary(
+    name: impl Into<Cow<'static, str>>,
+    summary: impl Into<DynCow<'static, dyn Summary>>,
+    metadata: Metadata,
+) -> Result<(), RegisterError> {
+    State::get_force().register_metric(name.into(), Metric::Summary(summary.into()), metadata)
+}
+
+/// Unregister an existing metric.
+///
+/// If there is no such metric returns an error.
+pub fn unregister_metric(name: impl AsRef<str>) -> Result<(), UnregisterError> {
+    match State::get() {
+        Some(state) => state.unregister_metric(name.as_ref()),
+        None => Ok(()),
+    }
+}
+
+/// Set the error function.
+///
+/// Due to the impracticality of having every single metric return a `Result`
+/// this library instead opts to have an internal error function that is called
+/// whenever an error occurs.
+///
+/// The default error function will log a warning when an error occurrs.
+pub fn set_error_fn(err_fn: impl Fn(MetricError) + Send + Sync + 'static) {
+    use std::sync::Arc;
+
+    State::get_force().set_error_fn(Arc::new(err_fn));
+}
+
+/// Run a function over each metric and collect the result into a container.
+///
+/// Due to the underlying API limitations of evmap this is the only way to
+/// introspect existing metrics.
+pub fn for_each_metric<C, F, R>(func: F) -> C
+where
+    C: std::iter::FromIterator<R>,
+    F: FnMut(&str, &MetricInstance) -> R,
+{
+    match State::get() {
+        Some(state) => state.for_each_metric(func),
+        None => C::from_iter(std::iter::empty()),
+    }
+}
+
+#[doc(hidden)]
+pub mod export {
+    use super::*;
+
+    pub fn create_metadata(attributes: &'static [(&'static str, &'static str)]) -> Metadata {
+        Metadata::new(attributes)
+    }
+
+    pub fn current_time() -> Instant {
+        Instant::now()
+    }
+
+    /// Record a value to a metric. This corresponds to the `value!` macro.
+    #[inline]
+    pub fn record_value(
+        name: impl AsRef<str>,
+        value: impl Into<MetricValue>,
+        count: u64,
+        time: Instant,
+    ) {
+        if let Some(state) = State::get() {
+            state.record_value(name.as_ref(), value.into(), count, time);
+        }
+    }
+
+    /// Record an increment to a counter or gauge. This corresponds to the
+    /// `increment!` macro.
+    #[inline]
+    pub fn record_increment(name: impl AsRef<str>, amount: impl Into<MetricValue>, time: Instant) {
+        if let Some(state) = State::get() {
+            state.record_increment(name.as_ref(), amount.into(), time)
+        }
+    }
+
+    /// Record a decrement to a gauge. This corresponds to the `decrement!`
+    /// macro.
+    #[inline]
+    pub fn record_decrement(name: impl AsRef<str>, amount: impl Into<MetricValue>, time: Instant) {
+        if let Some(state) = State::get() {
+            state.record_decrement(name.as_ref(), amount.into(), time)
+        }
+    }
+
+    /// Record a value, calls the error function if the metric is not a counter.
+    #[inline]
+    pub fn record_counter_value(name: impl AsRef<str>, amount: u64, time: Instant) {
+        if let Some(state) = State::get() {
+            state.record_counter_value(name.as_ref(), amount, time);
+        }
+    }
+
+    /// Record a value, calls the error function if the metric is not a gauge.
+    #[inline]
+    pub fn record_gauge_value(name: impl AsRef<str>, amount: i64, time: Instant) {
+        if let Some(state) = State::get() {
+            state.record_gauge_value(name.as_ref(), amount, time);
+        }
+    }
+}

--- a/metrics-core/src/macros.rs
+++ b/metrics-core/src/macros.rs
@@ -1,0 +1,416 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Record a value to a metric.
+///
+/// For counters and gauges this should directly set the value of the metric,
+/// for histograms it will get rolled into a summary.
+///
+/// The required parameters for this macro are
+/// - `name`: a string literal with the name of the metric
+/// - `value`: the value to be recorded
+///
+/// Optional parameters
+/// - `count`: The number of times the value should be registered. This is
+///     ignored for counters and gauges. If not given, this defaults to 1.
+/// - `time`: The time at which the value was recorded, given as
+///     `time = <expr>`. If not given then defaults to the current time.
+///
+/// # Example
+/// ```
+/// use metrics_core::{value, Instant};
+///
+/// // Set the value of the metric with the current timestamp
+/// value!("my-metric", 15);
+///
+/// // Set the value of the metrics 16 times with the current timestamp.
+/// // This is only different from the first one if "my-metric" is a
+/// // summary. Otherwise, it has the exact same behaviour.
+/// value!("my-metric", 15, 16);
+///
+/// // Set the value of the metric with an explicit time. Normally this
+/// // isn't necessary but it is useful if you want to avoid getting
+/// // the current time multiple times when setting a number of metrics.
+/// let now = Instant::now();
+/// value!("my-metric-1", 15, time = now);
+/// value!("my-metric-2", 727, time = now);
+/// value!("my-metric-3", 222, 23, time = now);
+/// ```
+#[macro_export]
+macro_rules! value {
+    ($name:literal, $value:expr) => {
+        value!($name, $value, 1)
+    };
+    ($name:literal, $value:expr, time = $time:expr) => {
+        value!($name, $value, 1, time = $time)
+    };
+    ($name:literal, $value:expr, $count:expr) => {
+        value!($name, $value, $count, time = $crate::export::current_time())
+    };
+    ($name:literal, $value:expr, $count:expr, time=$time:expr) => {
+        $crate::export::record_value($name, $value, $count, $time)
+    };
+}
+
+/// Increment a counter or gauge.
+///
+/// If the metric is a counter or a gauge then it will increment the stored
+/// value within the metric. If the provided metric is not a histogram, then it
+/// will call the user-provided error function.
+///
+/// The the only required parameter for this macro is
+/// - `name`: a string literal with the name of the metric.
+///
+/// Optional Paramters
+/// - `value`: the amount by which to increment the counter/gauge. If not
+///     specified this defaults to `1`.
+/// - `time`: The time at which the increment happened. If not specified this
+///     defaults to the current time. Specified like `time = <expr>`.
+///
+/// # Example
+/// ```
+/// use metrics_core::{increment, Instant};
+///
+/// // Increase the value of "my-metric" by 1.
+/// increment!("my-metric");
+///
+/// // Increment the metric with an explicit time. Normally this isn't
+/// // necessary but it is useful if you want to avoid getting the current
+/// // time multiple times when incrementing multiple metrics.
+/// let now = Instant::now();
+/// increment!("my-metric-1", 15, time = now);
+/// increment!("my-metric-2", time = now);
+/// ```
+#[macro_export]
+macro_rules! increment {
+    ($name:literal) => {
+        increment!($name, 1)
+    };
+    ($name:literal, time = $time:expr) => {
+        increment!($name, 1, time = $time)
+    };
+    ($name:literal, $value:expr) => {
+        increment!($name, $value, time = $crate::export::current_time())
+    };
+    ($name:literal, $value:expr, time = $time:expr) => {
+        $crate::export::record_increment($name, $value, $time)
+    };
+}
+
+/// Decrement a gauge.
+///
+/// If the metric is a gauge then it will decrement the stored value within the
+/// metric. If the provided metric is not a gauge, then it will call the
+/// user-provided error function.
+///
+/// The the only required parameter for this macro is
+/// - `name`: a string literal with the name of the metric.
+///
+/// Optional Paramters
+/// - `value`: the amount by which to decrement the gauge.
+///     If not specified this defaults to `1`.
+/// - `time`: The time at which the decrement happened. If not specified
+///     this defaults to the current time. Specified like `time = <expr>`.
+///
+/// # Example
+/// ```
+/// use metrics_core::{decrement, Instant};
+///
+/// // Decrease the value of "my-metric" by 1.
+/// decrement!("my-metric");
+///
+/// // Decrement the metric with an explicit time. Normally this isn't
+/// // necessary but it is useful if you want to avoid getting the current
+/// // time multiple times when incrementing multiple metrics.
+/// let now = Instant::now();
+/// decrement!("my-metric-1", 15, time = now);
+/// decrement!("my-metric-2", time = now);
+/// ```
+#[macro_export]
+macro_rules! decrement {
+    ($name:literal) => {
+        decrement!($name, 1)
+    };
+    ($name:literal, time = $time:expr) => {
+        decrement!($name, 1, time = $time)
+    };
+    ($name:literal, $value:expr) => {
+        decrement!($name, $value, time = $crate::export::current_time())
+    };
+    ($name:literal, $value:expr, time = $time:expr) => {
+        $crate::export::record_decrement($name, $value, $time)
+    };
+}
+
+/// Set the value of a counter.
+///
+/// If the metric is not a counter then it will call the user-defined error
+/// function.
+///
+/// ## Parameters
+/// - `name`: A string literal with the name of the metric.
+/// - `value`: The new value of the counter.
+/// - `time`: The time at which the value was recorded.
+///   Specified like `time = <expr>`.
+///
+/// # Example
+/// ```
+/// # use metrics_core::counter;
+/// // Set the value of "my-metric" only if it is a counter and call the
+/// // error function otherwise.
+/// counter!("my-metric", 33);
+/// ```
+#[macro_export]
+macro_rules! counter {
+    ($name:literal, $value:expr) => {
+        counter!($name, $value, time = $crate::export::current_time())
+    };
+    ($name:literal, $value:expr, time = $time:expr) => {
+        $crate::export::record_counter_value($name, $value, $time)
+    };
+}
+
+/// Set the value of a gauge.
+///
+/// If the metric is not a gauge then it will call the user-defined error
+/// function.
+///
+/// ## Parameters
+/// - `name`: A string literal with the name of the metric.
+/// - `value`: The new value of the gauge.
+/// - `time`: The time at which the value was recorded.
+///   Specified like `time = <expr>`.
+///
+/// # Example
+/// ```
+/// # use metrics_core::gauge;
+/// // Set the value of "my-metric" only if it is a counter and call the
+/// // error function otherwise.
+/// gauge!("my-metric", 33);
+/// ```
+#[macro_export]
+macro_rules! gauge {
+    ($name:literal, $value:expr) => {
+        gauge!($name, $value, time = $crate::export::current_time())
+    };
+    ($name:literal, $value:expr, time = $time:expr) => {
+        $crate::export::record_gauge_value($name, $value, $time)
+    };
+}
+
+/// Record a timing interval.
+///
+/// This is equivalent to calling `value!` with the interval.
+///
+/// This macro supports two argument formats. Either it takes the duration the
+/// interval or it takes a start and end time and uses that to calculate the
+/// interval duration.
+///
+/// # Example
+/// ```
+/// # fn some_fn() {}
+/// use metrics_core::{interval, Interval, Instant};
+///
+/// // Record an interval of length 30ms ending at the current time
+/// interval!("my-metric", Interval::from_millis(30));
+///
+/// // Time some_fn and record it
+/// let start = Instant::now();
+/// some_fn();
+/// let end = Instant::now();
+/// interval!("some_fn_length", start, end);
+/// ```
+#[macro_export]
+macro_rules! interval {
+    ($name:literal, $value:expr) => {
+        $crate::export::record_value($name, $value, 1, $crate::export::current_time())
+    };
+    ($name:literal, $start:expr, $end:expr) => {
+        $crate::export::record_value($name, $start - $end, 1, $end)
+    };
+}
+
+/// Register a new counter metric.
+///
+/// ## Parameters
+/// - `name`: A string name that the metric will be registered under.
+/// - `counter`: The actual counter metric.
+/// - `metadata`: Arbitrary metadata associated with the metric. See the
+///     [`metadata!`](crate::metadata) macro for the syntax.
+#[macro_export]
+macro_rules! register_counter {
+    (
+        $name:expr,
+        $counter:expr
+        $( ,
+            { $( $key:ident : $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_counter!($name, $counter, $crate::metadata! {
+            $( $key : $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $counter:expr,
+        $( ,
+            { $( $key:expr => $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_counter!($name, $counter, $crate::metadata! {
+            $( $key => $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $counter:expr,
+        $metadata:expr $(,)?
+    ) => {
+        $crate::register_counter(
+            $name,
+            $counter,
+            $metadata
+        )
+    }
+}
+
+/// Register a new gauge metric
+///
+/// ## Parameters
+/// - `name`: A string name that the metric will be registered under.
+/// - `gauge`: The actual gauge metric.
+/// - `metadata`: Arbitrary metadata associated with the metric. See the
+///     [`metadata!`](crate::metadata) macro for the syntax.
+#[macro_export]
+macro_rules! register_gauge {
+    (
+        $name:expr,
+        $gauge:expr
+        $( ,
+            { $( $key:tt : $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_gauge!($name, $gauge, $crate::metadata! {
+            $( $key : $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $gauge:expr,
+        $( ,
+            { $( $key:expr => $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_gauge!($name, $gauge, $crate::metadata! {
+            $( $key => $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $gauge:expr,
+        $metadata:expr $(,)?
+    ) => {
+        $crate::register_gauge(
+            $name,
+            $counter,
+            $metadata
+        )
+    }
+}
+
+/// Register a new summary.
+///
+/// ## Parameters
+/// - `name`: A string name that the metric will be registered under.
+/// - `summary`: The actual summary metric.
+/// - `metadata`: Arbitrary metadata associated with the metric. See the
+///     [`metadata!`](crate::metadata) macro for the syntax.
+#[macro_export]
+macro_rules! register_summary {
+    (
+        $name:expr,
+        $histogram:expr
+        $( ,
+            { $( $key:tt : $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_histogram!($name, $histogram, $crate::metadata! {
+            $( $key : $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $histogram:expr,
+        $( ,
+            { $( $key:expr => $val:expr ),* $(,)? }
+        )? $(,)?
+    ) => {
+        register_counter!($name, $histogram, $crate::metadata! {
+            $( $key => $val ),*
+        })
+    };
+    (
+        $name:expr,
+        $histogram:expr,
+        $metadata:expr $(,)?
+    ) => {
+        $crate::register_histogram(
+            $name,
+            $counter,
+            $metadata
+        )
+    }
+}
+
+/// Create a metadata dictionary.
+///
+/// Metadata can contain arbitrary key-value pairs
+/// as long as the keys and values are strings with
+/// a static lifetime.
+///
+/// # Example
+/// ```
+/// # use metrics_core::*;
+///
+/// // Can use this syntax
+/// let metdata = metadata! {
+///     unit: "ms",
+///     foo: "bar",
+///     type: "histogram"
+/// };
+///
+/// // Or this syntax.
+/// let metadata = metadata! {
+///     "unit" => "ms",
+///     "foo" => "bar",
+///     "type" => "histogram",
+/// };
+/// ```
+#[macro_export]
+macro_rules! metadata {
+    {
+        $( $key:ident : $val:expr ),* $(,)?
+    } => {
+        $crate::export::create_metadata(&[
+            $( ( stringify!($key), $val ) ),*
+        ])
+    };
+    {
+        $( $key:expr => $val:expr ),* $(,)?
+    } => {
+        $crate::export::create_metadata(&[
+            $( ( $key, $val ) ),*
+        ])
+    };
+}
+
+/// Create a percentile from a float.
+///
+/// This corresponds to calling `Percentile::from_float`.
+#[macro_export]
+macro_rules! percentile {
+    ( $p:expr ) => {
+        $crate::Percentile::from_float($p)
+    };
+}

--- a/metrics-core/src/metadata.rs
+++ b/metrics-core/src/metadata.rs
@@ -1,0 +1,99 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::ops::Index;
+
+const EMPTY_ARRAY: &[(&str, &str)] = &[];
+
+/// A static map of key-value pairs.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Metadata {
+    attributes: &'static [(&'static str, &'static str)],
+}
+
+impl Metadata {
+    // Note: This is not public since in the future we may want to enforce that
+    // these are sorted
+    pub(crate) fn new(attributes: &'static [(&'static str, &'static str)]) -> Self {
+        Self { attributes }
+    }
+
+    /// Get an iterator over the key-value pairs stored in this `Metadata`
+    /// instance.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, &'static str)> {
+        self.attributes.iter().copied()
+    }
+
+    /// Get the value for the metadata key.
+    pub fn get(&self, val: &str) -> Option<&'static str> {
+        // TODO(sean): If we can guarantee that the attributes are always sorted
+        // then we can use a binary search here instead.
+        for (k, v) in self.iter() {
+            if k == val {
+                return Some(v);
+            }
+        }
+
+        None
+    }
+
+    /// Create an empty set of metadata
+    pub const fn empty() -> Self {
+        Self {
+            attributes: EMPTY_ARRAY,
+        }
+    }
+}
+
+impl Index<&'_ str> for Metadata {
+    type Output = str;
+
+    fn index(&self, key: &str) -> &'static str {
+        match self.get(key) {
+            Some(x) => x,
+            None => panic!("key `{}` not within the metadata map", key),
+        }
+    }
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Metadata::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn basic_metadata() {
+        let data = metadata! {
+            "str" => "x",
+            "a" => "b",
+            "units" => "ms",
+            "status" => "is a test",
+        };
+
+        assert_eq!(&data["a"], "b");
+        assert_eq!(&data["units"], "ms");
+        assert_eq!(&data["status"], "is a test");
+        assert_eq!(&data["str"], "x");
+        assert_eq!(data.get("status_"), None);
+        assert_eq!(data.get("not present"), None);
+    }
+
+    #[test]
+    fn struct_style_metadata() {
+        let data = metadata! {
+            unit: "ms",
+            status: "dead",
+            test: "true"
+        };
+
+        assert_eq!(&data["unit"], "ms");
+        assert_eq!(&data["status"], "dead");
+        assert_eq!(&data["test"], "true");
+        assert_eq!(data.get("u"), None);
+        assert_eq!(data.get(""), None);
+    }
+}

--- a/metrics-core/src/percentile.rs
+++ b/metrics-core/src/percentile.rs
@@ -1,0 +1,169 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#![allow(missing_docs)]
+
+const MAX_PERCENTILE: u32 = 1_000_000_000u32;
+
+/// A percentile. Used to calculate percentiles from a summary.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Percentile {
+    // Representation is a fixed-point number from 1 to 1000000000
+    // with 1000000000 being 1 and 0 being 0.
+    val: u32,
+}
+
+macro_rules! p {
+    ($val:expr) => {
+        Percentile { val: $val }
+    };
+}
+
+impl Percentile {
+    /// Create a new percentile from a value between `0` and `1_000_000_000`.
+    ///
+    /// If the value is out of range, returne `None`.
+    pub fn new(val: u32) -> Option<Self> {
+        if val > MAX_PERCENTILE {
+            return None;
+        }
+        Some(Percentile { val })
+    }
+
+    /// Create a new percentile from a value between `0` and `1_000_000_000`.
+    ///
+    /// Given the current limitations of const fn, this function is the
+    /// only way to create a percentile in a const context.
+    ///
+    /// # Safety
+    /// This function is unsafe since it allows for an invalid `Percentile`
+    /// to be created.
+    pub const unsafe fn new_unchecked(val: u32) -> Self {
+        Self { val }
+    }
+
+    /// Get the inner integer representation of this percentile.
+    pub const fn into_inner(self) -> u32 {
+        self.val
+    }
+
+    /// Convert a float to a `Percentile`.
+    ///
+    /// For floats outside the range of 0 to 1 this function will clamp
+    /// them to 0 or 1 respectively.
+    pub fn from_float(val: f64) -> Self {
+        Self {
+            val: (val.min(1.0).max(0.0) * (MAX_PERCENTILE as f64)) as u32,
+        }
+    }
+
+    /// Convert this percentile to a float.
+    pub fn as_float(self) -> f64 {
+        (self.val as f64) / (MAX_PERCENTILE as f64)
+    }
+
+    /// The 0th percentile. This corresponds to the minimum value within
+    /// the sample.
+    pub const fn minimum() -> Self {
+        p!(0)
+    }
+
+    /// The 100th percentile. This corresponds to the maximum value within
+    /// the sample.
+    pub const fn maximum() -> Self {
+        p!(MAX_PERCENTILE)
+    }
+
+    /// The 0.01th percentile. This corresponds to the value that is greater
+    /// than 0.01% of the sample.
+    pub const fn p001() -> Self {
+        p!(Self::maximum().val / 10000)
+    }
+
+    /// The 0.1th percentile. This corresponds to the value that is greater
+    /// than 0.1% of the sample.
+    pub const fn p01() -> Self {
+        p!(Self::maximum().val / 1000)
+    }
+
+    /// The 1st percentile. This corresponds to the value that is greater
+    /// than 1% of the sample.
+    pub const fn p1() -> Self {
+        p!(Self::maximum().val / 100)
+    }
+
+    /// The 5th percentile. This correspnods to the value that is greater
+    /// than 5% of the sample.
+    pub const fn p5() -> Self {
+        p!(Self::maximum().val / 20)
+    }
+
+    /// The 10th percentile. This corresponds to the value that is greater
+    /// than 10% of the sample.
+    pub const fn p10() -> Self {
+        p!(Self::maximum().val / 10)
+    }
+
+    /// The 25th percentile. This corresponds to the value that is greater
+    /// than 25% of the sample.
+    pub const fn p25() -> Self {
+        p!(Self::maximum().val / 4)
+    }
+
+    /// The 50th percentile. This corresponds to the value that is greater
+    /// than 50% of the sample.
+    ///
+    /// Note that this is the median of the sample.
+    pub const fn p50() -> Self {
+        p!(Self::maximum().val / 2)
+    }
+
+    /// The 75th percentile. This corresponds to the value that is greater than
+    /// 75% of the sample.
+    pub const fn p75() -> Self {
+        p!(Self::p25().val * 3)
+    }
+
+    /// The 90th percentile. This corresponds to the value that is greater than
+    /// 90% of the sample.
+    pub const fn p90() -> Self {
+        p!(Self::p10().val * 9)
+    }
+
+    /// The 95th percentile. This corresponds to the value that is greater than
+    /// 95% of the sample.
+    pub const fn p95() -> Self {
+        p!(Self::maximum().val - Self::p5().val)
+    }
+
+    /// The 99th percentile. This corresponds to the value that is greater than
+    /// 99% of the sample.
+    pub const fn p99() -> Self {
+        p!(Self::maximum().val - Self::p1().val)
+    }
+
+    /// The 99.9th percentile. This corresponds to the value that is greater
+    /// than 99.9% of the sample.
+    pub const fn p999() -> Self {
+        p!(Self::maximum().val - Self::p01().val)
+    }
+
+    /// The 99.99th percentile. This corresponds to the value that is greater
+    /// than 99.99% of the sample.
+    pub const fn p9999() -> Self {
+        p!(Self::maximum().val - Self::p001().val)
+    }
+}
+
+impl From<Percentile> for f64 {
+    fn from(x: Percentile) -> f64 {
+        x.as_float()
+    }
+}
+
+impl From<f64> for Percentile {
+    fn from(x: f64) -> Self {
+        Self::from_float(x)
+    }
+}

--- a/metrics-core/src/scoped.rs
+++ b/metrics-core/src/scoped.rs
@@ -1,0 +1,94 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::borrow::Cow;
+use std::marker::PhantomData;
+use std::mem;
+
+use crate::{
+    register_counter, register_gauge, register_summary, unregister_metric, Counter, Gauge,
+    Metadata, MetricCommon, RegisterError, Summary,
+};
+
+/// A metric with a non-static lifetime.
+///
+/// This type allows for stack-allocated metrics to be used easily and
+/// conveniently.
+///
+/// # Safety
+/// For this type to be safe you must ensure that its drop implementation is
+/// run. If this doesn't happen then values recorded to this metric will use a
+/// dangling reference.
+///
+/// For this reason, all constructors on this type are `unsafe`.
+pub struct ScopedMetric<'m, M: MetricCommon> {
+    marker: PhantomData<&'m M>,
+    name: Cow<'static, str>,
+}
+
+impl<'m, M: Counter> ScopedMetric<'m, M> {
+    /// Create a scoped counter from an existing counter reference.
+    pub unsafe fn counter(
+        name: impl Into<Cow<'static, str>>,
+        metric: &'m M,
+        metadata: impl Into<Option<Metadata>>,
+    ) -> Result<Self, RegisterError> {
+        let static_metric: &'static dyn Counter = mem::transmute(metric as &dyn Counter);
+        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let name = name.into();
+
+        register_counter(name.clone(), static_metric, metadata)?;
+
+        Ok(Self {
+            marker: PhantomData,
+            name,
+        })
+    }
+}
+
+impl<'m, M: Gauge> ScopedMetric<'m, M> {
+    /// Create a scoped gauge from an existing gauge reference.
+    pub unsafe fn gauge(
+        name: impl Into<Cow<'static, str>>,
+        metric: &'m M,
+        metadata: impl Into<Option<Metadata>>,
+    ) -> Result<Self, RegisterError> {
+        let static_metric: &'static dyn Gauge = mem::transmute(metric as &dyn Gauge);
+        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let name = name.into();
+
+        register_gauge(name.clone(), static_metric, metadata)?;
+
+        Ok(Self {
+            marker: PhantomData,
+            name,
+        })
+    }
+}
+
+impl<'m, M: Summary> ScopedMetric<'m, M> {
+    /// Create a scoped summary from an existing summary reference.
+    pub unsafe fn summary(
+        name: impl Into<Cow<'static, str>>,
+        metric: &'m M,
+        metadata: impl Into<Option<Metadata>>,
+    ) -> Result<Self, RegisterError> {
+        let static_metric: &'static dyn Summary = mem::transmute(metric as &dyn Summary);
+        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let name = name.into();
+
+        register_summary(name.clone(), static_metric, metadata)?;
+
+        Ok(Self {
+            marker: PhantomData,
+            name,
+        })
+    }
+}
+
+impl<'m, M: MetricCommon> Drop for ScopedMetric<'m, M> {
+    fn drop(&mut self) {
+        let _ = unregister_metric(&self.name);
+    }
+}

--- a/metrics-core/src/state.rs
+++ b/metrics-core/src/state.rs
@@ -1,0 +1,254 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::borrow::Cow;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use evmap;
+use once_cell::sync::Lazy;
+use thread_local::CachedThreadLocal;
+
+use crate::{
+    Instant, Metadata, Metric, MetricError, MetricInstance, MetricType, MetricValue, RegisterError,
+    UnregisterError,
+};
+
+#[derive(Clone)]
+pub(crate) struct GlobalMetadata {
+    error_fn: Arc<dyn Fn(MetricError) + Send + Sync>,
+}
+
+impl Default for GlobalMetadata {
+    fn default() -> Self {
+        Self {
+            error_fn: Arc::new(default_error_fn),
+        }
+    }
+}
+
+fn default_error_fn(err: MetricError) {
+    warn!("A metric error occurred: {}", err);
+}
+
+type WriteHandle = evmap::WriteHandle<Cow<'static, str>, MetricInstance, GlobalMetadata>;
+type ReadHandle = evmap::ReadHandle<Cow<'static, str>, MetricInstance, GlobalMetadata>;
+type ReadHandleFactory =
+    evmap::ReadHandleFactory<Cow<'static, str>, MetricInstance, GlobalMetadata>;
+
+// TODO(sean): Use alternate OnceCell implementation here so that
+//             we can get rid of this variable here.
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+static STATE: Lazy<State> = Lazy::new(|| {
+    INITIALIZED.store(true, Ordering::Relaxed);
+    State::new()
+});
+
+pub(crate) struct State {
+    writer: Mutex<WriteHandle>,
+    factory: ReadHandleFactory,
+    tls: CachedThreadLocal<ReadHandle>,
+}
+
+impl State {
+    fn new() -> Self {
+        let (reader, writer) = evmap::with_meta(GlobalMetadata::default());
+
+        Self {
+            writer: Mutex::new(writer),
+            factory: reader.factory(),
+            tls: CachedThreadLocal::new(),
+        }
+    }
+
+    fn reader(&self) -> &ReadHandle {
+        self.tls.get_or(|| self.factory.handle())
+    }
+
+    /// Get the state if it has been initialized otherwise just return None.
+    ///
+    /// This is useful for cases where we wouldn't do anything with an empty
+    /// state anyways. (specifically, recording a value to a metric. If the
+    /// state hasn't been set up then the metric definitely doesn't exist.)
+    #[inline]
+    pub(crate) fn get() -> Option<&'static Self> {
+        if INITIALIZED.load(Ordering::Relaxed) {
+            Some(&*STATE)
+        } else {
+            None
+        }
+    }
+
+    /// If the value hasn't been initializes then it creates it as well
+    #[inline]
+    pub(crate) fn get_force() -> &'static Self {
+        &*STATE
+    }
+
+    /// Register a new metric, returns whether the metric was registered
+    /// successfully
+    pub(crate) fn register_metric(
+        &self,
+        name: Cow<'static, str>,
+        metric: Metric,
+        metadata: Metadata,
+    ) -> Result<(), RegisterError> {
+        let mut writer = self.writer.lock().unwrap();
+        let instance = MetricInstance::new(metric, metadata);
+
+        if writer.is_destroyed() {
+            return Err(RegisterError::LibraryShutdown);
+        }
+
+        if writer.contains_key(&name) {
+            return Err(RegisterError::MetricAlreadyExists);
+        }
+
+        writer.update(name, instance);
+
+        writer.refresh();
+
+        return Ok(());
+    }
+
+    /// Unregister an existing metric, if the metric doesn't exist then this
+    /// method does nothing.
+    ///
+    // TODO: I'd like to somehow return the existing entry in the hash table.
+    //       Unfortunately, evmap doesn't offer an API to get the removed value
+    //       or even to tell if we removed a value.
+    pub(crate) fn unregister_metric(&self, name: &str) -> Result<(), UnregisterError> {
+        let mut writer = self.writer.lock().unwrap();
+
+        if writer.is_destroyed() {
+            return Err(UnregisterError::LibraryShutdown);
+        }
+
+        if !writer.contains_key(name) {
+            return Err(UnregisterError::NoSuchMetric);
+        }
+
+        // Hack to get a Cow with a static lifetime
+        // this is safe since we immediately call writer.refresh
+        writer.empty(Cow::Borrowed(unsafe { &*(name as *const str) }));
+        writer.refresh();
+
+        Ok(())
+    }
+
+    pub(crate) fn set_error_fn(&self, err_fn: Arc<dyn Fn(MetricError) + Send + Sync>) {
+        let mut writer = self.writer.lock().unwrap();
+
+        let mut meta = writer.meta().unwrap();
+        meta.error_fn = err_fn;
+        writer.set_meta(meta);
+
+        writer.refresh();
+    }
+
+    #[cold]
+    fn error(&self, err: MetricError) {
+        let reader = self.reader();
+
+        if let Some(meta) = reader.meta() {
+            (*meta.error_fn)(err);
+        }
+    }
+
+    pub(crate) fn record_value(&self, name: &str, value: MetricValue, count: u64, time: Instant) {
+        let reader = self.reader();
+
+        reader.get_and(name, |val| match val[0].metric() {
+            Metric::Counter(counter) => match value.as_u64() {
+                Some(val) => counter.store(time, val),
+                _ => self.error(MetricError::invalid_unsigned(
+                    name,
+                    value.as_i64_unchecked(),
+                )),
+            },
+            Metric::Gauge(gauge) => match value.as_i64() {
+                Some(val) => gauge.store(time, val),
+                _ => self.error(MetricError::invalid_signed(name, value.as_u64_unchecked())),
+            },
+            Metric::Summary(histogram) => match value.as_u64() {
+                Some(val) => histogram.record(time, val, count),
+                _ => self.error(MetricError::invalid_unsigned(
+                    name,
+                    value.as_i64_unchecked(),
+                )),
+            },
+        });
+    }
+
+    pub(crate) fn record_increment(&self, name: &str, value: MetricValue, time: Instant) {
+        let reader = self.reader();
+
+        reader.get_and(name, |val| match val[0].metric() {
+            Metric::Counter(counter) => match value.as_u64() {
+                Some(val) => counter.add(time, val),
+                None => self.error(MetricError::invalid_unsigned(
+                    name,
+                    value.as_i64_unchecked(),
+                )),
+            },
+            Metric::Gauge(gauge) => match value.as_i64() {
+                Some(val) => gauge.add(time, val),
+                None => self.error(MetricError::invalid_signed(name, value.as_u64_unchecked())),
+            },
+            Metric::Summary(_) => {
+                self.error(MetricError::invalid_increment(name, MetricType::Summary))
+            }
+        });
+    }
+
+    pub(crate) fn record_decrement(&self, name: &str, value: MetricValue, time: Instant) {
+        let reader = self.reader();
+
+        reader.get_and(name, |val| match val[0].metric() {
+            Metric::Gauge(gauge) => match value.as_i64() {
+                Some(val) => gauge.sub(time, val),
+                None => self.error(MetricError::invalid_signed(name, value.as_u64_unchecked())),
+            },
+            metric => self.error(MetricError::invalid_decrement(name, metric.ty())),
+        });
+    }
+
+    pub(crate) fn record_counter_value(&self, name: &str, value: u64, time: Instant) {
+        let reader = self.reader();
+
+        reader.get_and(name, |val| match val[0].metric() {
+            Metric::Counter(counter) => counter.store(time, value),
+            metric => self.error(MetricError::wrong_type(
+                name,
+                MetricType::Counter,
+                metric.ty(),
+            )),
+        });
+    }
+
+    pub(crate) fn record_gauge_value(&self, name: &str, value: i64, time: Instant) {
+        let reader = self.reader();
+
+        reader.get_and(name, |val| match val[0].metric() {
+            Metric::Gauge(gauge) => gauge.store(time, value),
+            metric => self.error(MetricError::wrong_type(
+                name,
+                MetricType::Gauge,
+                metric.ty(),
+            )),
+        });
+    }
+
+    pub(crate) fn for_each_metric<F, R, C>(&self, mut func: F) -> C
+    where
+        C: std::iter::FromIterator<R>,
+        F: FnMut(&str, &MetricInstance) -> R,
+    {
+        let reader = self.reader();
+
+        reader.map_into(move |key, vals| func(&*key, &vals[0]))
+    }
+}

--- a/metrics-core/src/submetric.rs
+++ b/metrics-core/src/submetric.rs
@@ -1,0 +1,81 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::borrow::Cow;
+
+/// A value returned from a submetric.
+///
+/// This is meant to allow submetrics to return any value
+/// that can reasonably be supported in downstream systems.
+#[derive(Copy, Clone, Debug)]
+pub enum SubMetricValue {
+    /// An unsigned integer
+    Unsigned(u64),
+    /// A signed integer
+    Signed(i64),
+    /// A floating point number
+    Float(f64),
+}
+
+/// A bucket within a histogram.
+///
+/// It has minimum and maximum bounds on the bucket as well
+/// as the number of samples stored within the bucket.
+#[derive(Copy, Clone, Debug)]
+pub struct Bucket {
+    /// The lower bound of the bucket
+    pub min: u64,
+    /// The upper bound of the bucket
+    pub max: u64,
+    /// The number of samples within the bucket.
+    pub count: u64,
+}
+
+/// An arbitrary stat returned by a summary.
+#[derive(Clone, Debug)]
+pub struct SubMetric {
+    /// The name of the submetric
+    pub name: Cow<'static, str>,
+    /// The value of the submetric
+    pub value: SubMetricValue,
+}
+
+impl SubMetric {
+    /// Create a new submetric with a name and value.
+    pub fn new(name: impl Into<Cow<'static, str>>, value: impl Into<SubMetricValue>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
+macro_rules! decl_from_submetricvalue {
+    {
+        $( $ty:ty => $class:ident; )*
+    } => {
+        $(
+            impl From<$ty> for SubMetricValue {
+                fn from(v: $ty) -> Self {
+                    Self::$class(v.into())
+                }
+            }
+        )*
+    }
+}
+
+decl_from_submetricvalue! {
+    u64 => Unsigned;
+    u32 => Unsigned;
+    u16 => Unsigned;
+    u8  => Unsigned;
+
+    i64 => Signed;
+    i32 => Signed;
+    i16 => Signed;
+    i8  => Signed;
+
+    f32 => Float;
+    f64 => Float;
+}

--- a/metrics-core/src/traits.rs
+++ b/metrics-core/src/traits.rs
@@ -1,0 +1,86 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::any::Any;
+
+use crate::submetric::Bucket;
+use crate::{Instant, Percentile, SubMetric, SummaryError};
+
+/// Methods common to all metrics.
+pub trait MetricCommon: Send + Sync {
+    /// Get the current metric as a pointer to a type implementing `Any`.
+    fn as_any(&self) -> Option<&dyn Any> {
+        None
+    }
+}
+
+// TODO(bmartin): consider making these generic in terms of primitive type.
+
+/// A counter. Counts things.
+///
+/// This trait should be implemented by any type that should be used as a
+/// counter metric.
+///
+/// Counters should be used when counting something. (e.g. the total number of
+/// hits on a web endpoint, the number of times that a function has run, etc.)
+pub trait Counter: MetricCommon {
+    /// Set the value of the counter.
+    fn store(&self, time: Instant, value: u64);
+
+    /// Add a value to the counter.
+    fn add(&self, time: Instant, value: u64);
+
+    /// Get the current value of the counter.
+    fn load(&self) -> u64;
+}
+
+/// A gauge. Measures the instantaneous value of some property.
+///
+/// This trait should be implemented by any type that can be used as a gauge
+/// metric.
+///
+/// Gauges measure the instantaneous value of some property. (e.g. number of
+/// requests currently in flight, current CPU usage, memory usage, etc.)
+pub trait Gauge: MetricCommon {
+    /// Store a value into the gauge.
+    fn store(&self, time: Instant, value: i64);
+
+    /// Add a value to the gauge.
+    fn add(&self, time: Instant, value: i64);
+
+    /// Subtract a value from the gauge.
+    fn sub(&self, time: Instant, value: i64);
+
+    /// Get the current value of the gauge.
+    fn load(&self) -> u64;
+}
+
+/// Any sort of summary of the record values
+pub trait Summary: MetricCommon {
+    /// Record `count` instances of `value`.
+    fn record(&self, time: Instant, value: u64, count: u64);
+
+    // TODO: we should consider alternate design here. It's more likely that
+    // we'd want to get some preset group of submetrics (eg: particular
+    // quantiles) it's unclear how we'd tell the implementation about those in
+    // the current form.
+
+    /// Query quantiles from a summary.
+    ///
+    /// If this summary cannot produce quantiles, then it
+    /// should return `SummaryError::Unsupported`.
+    fn quantiles(&self, quantiles: &[Percentile], results: &mut [u64]) -> Result<(), SummaryError>;
+
+    /// Query buckets from a summary.
+    ///
+    /// If this summary doesn't support buckets, then it
+    /// should return `SummaryError::Unsupported`.
+    fn buckets(&self) -> Result<Vec<Bucket>, SummaryError>;
+
+    /// Get all custom statistics exposed by the implementation.
+    ///
+    /// If the summary doesn't export any custom statistics, then
+    /// it should return `SummaryError::Unsupported`.
+    fn submetrics(&self) -> Result<Vec<SubMetric>, SummaryError>;
+}

--- a/metrics-core/src/value.rs
+++ b/metrics-core/src/value.rs
@@ -1,0 +1,106 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+/// A value that can be recorded into a metric.
+///
+/// You shouldn't have to deal with this in most code. It is used by this
+/// library to accept a wider variety of types.
+///
+/// However, if you want to make your type something that can be natively
+/// accepted by this metrics library, implement `From` or `Into<MetricsValue>`
+/// for your type.
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug)]
+pub enum MetricValue {
+    Signed(i64),
+    Unsigned(u64),
+}
+
+impl MetricValue {
+    /// Get this value as a `u64` if it can be converted losslessly.
+    #[inline]
+    pub fn as_u64(self) -> Option<u64> {
+        match self {
+            Self::Signed(x) if x >= 0 => Some(x as u64),
+            Self::Signed(_) => None,
+            Self::Unsigned(x) => Some(x),
+        }
+    }
+
+    /// Get this value as a `i64` if it can be converted losslessly.
+    #[inline]
+    pub fn as_i64(self) -> Option<i64> {
+        match self {
+            Self::Unsigned(x) if x > std::i64::MAX as u64 => None,
+            Self::Unsigned(x) => Some(x as i64),
+            Self::Signed(x) => Some(x),
+        }
+    }
+
+    /// Convert this value to a `u64`.
+    #[inline]
+    pub fn as_u64_unchecked(self) -> u64 {
+        match self {
+            Self::Signed(x) => x as u64,
+            Self::Unsigned(x) => x,
+        }
+    }
+
+    /// Convert this value to an `i64`.
+    #[inline]
+    pub fn as_i64_unchecked(self) -> i64 {
+        match self {
+            Self::Signed(x) => x,
+            Self::Unsigned(x) => x as i64,
+        }
+    }
+}
+
+impl From<u8> for MetricValue {
+    fn from(v: u8) -> Self {
+        Self::Unsigned(v.into())
+    }
+}
+
+impl From<u16> for MetricValue {
+    fn from(v: u16) -> Self {
+        Self::Unsigned(v.into())
+    }
+}
+
+impl From<u32> for MetricValue {
+    fn from(v: u32) -> Self {
+        Self::Unsigned(v.into())
+    }
+}
+
+impl From<u64> for MetricValue {
+    fn from(v: u64) -> Self {
+        Self::Unsigned(v)
+    }
+}
+
+impl From<i8> for MetricValue {
+    fn from(v: i8) -> Self {
+        Self::Signed(v.into())
+    }
+}
+
+impl From<i16> for MetricValue {
+    fn from(v: i16) -> Self {
+        Self::Signed(v.into())
+    }
+}
+
+impl From<i32> for MetricValue {
+    fn from(v: i32) -> Self {
+        Self::Signed(v.into())
+    }
+}
+
+impl From<i64> for MetricValue {
+    fn from(v: i64) -> Self {
+        Self::Signed(v)
+    }
+}


### PR DESCRIPTION
Problem
Currently all our metrics are tied to a specific implementation. Instead we'd like to reduce the coupling between where metrics are recorded and where they are used. This would allow for replacing a metric with a new type transparently to end-user code. 

Solution
This PR implements a new metrics facade under `metrics-core`. It consists of
- A few different traits that individual metrics will implement based on their type. Specifically it has traits for counters, gauges, and summaries (anything that isn't a counter or gauge).
- A global trait registrar that allows a metric to be registered under a string name and then used.
- A set of macros which are used by client code to record a value under a metric named with a string.

In addition, this PR includes a limited introspection implementation that allows clients to iterate over all currently registered metrics. This meant to allow metrics to be exported globally without having to deal with the actual metric implementation types.

Result
All of this is available under `metrics-core`. Currently there are no types that implement the required traits for this to be used. This should be addressed in follow-up PRs.
