### PR TITLE
Add support for dumping summaries through the waterfall workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +71,26 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +102,16 @@ dependencies = [
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bstr"
@@ -178,6 +221,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "codec"
 version = "0.3.0"
 dependencies = [
@@ -189,6 +240,52 @@ dependencies = [
  "metrics 0.4.1",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-graphics"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-text"
+version = "13.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -308,6 +405,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -343,6 +449,7 @@ dependencies = [
  "atomics 0.3.0",
  "logger 0.1.0",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -361,9 +468,37 @@ version = "2.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dwrote"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "euclid"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "evmap"
@@ -371,6 +506,86 @@ version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "float-ord"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "font-kit"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 13.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "float-ord 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon_path 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "freetype"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-freetype-sys 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -400,6 +615,15 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gif"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -434,6 +658,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +700,14 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "latencygraph"
+version = "0.1.0"
+dependencies = [
+ "atomics 0.3.0",
+ "datastructures 0.4.0",
+ "plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -514,6 +770,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lyon_geom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lyon_path"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lyon_geom 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lzw"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +808,15 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -600,6 +888,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +907,26 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -648,6 +961,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "palette_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +1008,29 @@ dependencies = [
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plotters"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "font-kit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "palette 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "png"
@@ -851,6 +1207,17 @@ version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_users"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1267,21 @@ dependencies = [
  "waterfall 0.4.0",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rust-argon2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
@@ -976,6 +1358,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -995,6 +1380,34 @@ dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-fontconfig-sys 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "4.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-freetype-sys 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "servo-freetype-sys"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1039,12 +1452,28 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "superslice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1258,6 +1687,8 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1341,12 +1772,17 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "e19f23ab207147bbdbcdfa7f7e4ca5e84963d79bae3937074682177ab9150968"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
@@ -1360,6 +1796,13 @@ dependencies = [
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+"checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
+"checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+"checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
+"checksum core-text 13.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db84654ad95211c082cf9795f6f83dc17d0ae6c985ac1b906369dc7384ed346d"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
@@ -1369,47 +1812,73 @@ dependencies = [
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 "checksum crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum dejavu 2.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "017b75b5fbc5806d490da36acc5c4d0e4ae1b69890d02f24c268da971813fbc1"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum dwrote 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bd1369e02db5e9b842a9b67bce8a2fcc043beafb2ae8a799dd482d46ea1ff0d"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum euclid 0.20.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a8813df82772c5ef4c2e9cd4a986773c125ffeafdc08204c9d5c2f06e0abdc17"
 "checksum evmap 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4115e31301bb9dafa8ea8549432b14a51e19eecaa9e5c6041f099545e955c225"
+"checksum expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum float-ord 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+"checksum font-kit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b7ff8d2a0a660875d01689807925a45c5843bf90a1ef97ec52ef86ab0cafba"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "11926b2b410b469d0e9399eca4cbbe237a9ef02176c485803b29216307e8e028"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+"checksum gif 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "471d90201b3b223f3451cd4ad53e34295f16a1df17b1edf3736d47761c3981af"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hsl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "575fb7f1167f3b88ed825e90eb14918ac460461fdeaa3965c6a50951dee1c970"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum image 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4be8aaefbe7545dc42ae925afb55a0098f226a3fe5ef721872806f44f57826"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jpeg-decoder 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0256f0aec7352539102a9efbcb75543227b7ab1117e0f95450023af730128451"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum lyon_geom 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca04310c9807612a311506106000b6eccb2e27bca9bfb594ce80fb8a31231f9d"
+"checksum lyon_path 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bcb57ac24a5428539e2c7c0592766d5933c937d703f430990c669c00de96862"
+"checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+"checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
+"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6"
 "checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 "checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
+"checksum palette 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a05c0334468e62a4dfbda34b29110aa7d70d58c7fdb2c9857b5874dd9827cc59"
+"checksum palette_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b4b5f600e60dd3a147fb57b4547033d382d1979eb087af310e91cb45a63b1f4"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+"checksum plotters 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
 "checksum png 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f00ec9242f8e01119e83117dbadf34c5228ac2f1c4ddcd92bffa340d52291de"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
@@ -1429,8 +1898,11 @@ dependencies = [
 "checksum rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
+"checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
+"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa38506b5cbf2fb67f915e2725cb5012f1b9a785b0ab55c4733acda5f6554ef"
@@ -1443,6 +1915,9 @@ dependencies = [
 "checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+"checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
+"checksum servo-fontconfig-sys 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "62b3e166450f523f4db06c14f02a2d39e76d49b5d8cbd224338d93e3595c156c"
+"checksum servo-freetype-sys 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4ccb6d0d32d277d3ef7dea86203d8210945eb7a45fba89dd445b3595dd0dfc"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
@@ -1450,7 +1925,9 @@ dependencies = [
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stb_truetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "824210d6fb52cbc3ad2545270ead6860c7311aa5450642b078da4515937b6f7a"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88ddf1ad580c7e3d1efff877d972bcc93f995556b9087a5a259630985c88ceab"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "rpc-perf",
     "timer",
     "waterfall",
+    "latencygraph"
 ]
 
 [profile.dev]

--- a/datastructures/Cargo.toml
+++ b/datastructures/Cargo.toml
@@ -9,3 +9,8 @@ atomics = { path = "../atomics" }
 logger = { path = "../logger" }
 parking_lot = "0.9.0"
 time = "0.1.42"
+
+[dependencies.serde]
+version = "=1.0.102"
+optional = true
+features = [ "derive" ]

--- a/datastructures/src/ddsketch/atomic.rs
+++ b/datastructures/src/ddsketch/atomic.rs
@@ -1,0 +1,259 @@
+use crate::counter::{Counter, Saturating, Unsigned};
+
+use atomics::{AtomicPrimitive, AtomicU64, Ordering};
+
+/// An atomic DDSketch.
+pub struct DDSketch<T>
+where
+    T: Counter + Unsigned,
+    <T as AtomicPrimitive>::Primitive: Default + PartialEq + Copy + Saturating + Into<u64>,
+{
+    buckets: Vec<T>,
+
+    gamma: f64,
+    /// Number of linear-sized buckets before we switch to log sized buckets.
+    ///
+    /// This saves space since below a certain point log-sized buckets have a
+    /// width of less than 1 which is useless since we are storign integers.
+    cutoff: usize,
+
+    count: AtomicU64,
+    limit: u64,
+    min: AtomicU64,
+    max: AtomicU64,
+}
+
+impl<T> DDSketch<T>
+where
+    T: Counter + Unsigned,
+    <T as AtomicPrimitive>::Primitive: Default + PartialEq + Copy + Saturating + Into<u64>,
+{
+    /// Create a sketch that can store values up to `limit` with
+    /// a relative precision of `alpha`.
+    ///
+    /// # Panics
+    /// Panics if `alpha` is not in the range `(0, 1)` or if
+    /// *log<sub>(1 + alpha)/(1 - alpha)</sub>(limit)* is greater
+    /// than `std::i32::MAX`.
+    pub fn with_limit(limit: u64, alpha: f64) -> Self {
+        assert!(
+            alpha > 0.0 && alpha < 1.0,
+            "alpha must be in the range (0.0, 1.0)"
+        );
+
+        // Here's how the formula below works.
+        //
+        // First, to make the formulas shorter, define
+        //    γ = (1 + α) / (1 - α)
+        // This is the ratio between the maximum and minumum value
+        // within a bucket.
+        //
+        // So we want to figure out the number of buckets that we store
+        // within the sketch. The naive way to do this is to use
+        //     log_γ(limit) + 1
+        // buckets. (log_γ(limit) buckets between 1 and limit and 1 extra
+        // for zero.) However, this is wasteful since there will be a bunch
+        // of buckets near 1 that will have width smaller than 1 and so
+        // would be permanently empty. Instead, we'd like to have an exact
+        // histogram up to a certain number, then switch over to the log-sized
+        // histogram.
+        //
+        // The best point to do this is once the log-sized have a size of 1.
+        // This happens at index
+        //     log_γ (1 / (γ - 1)) = -log_γ(γ - 1)
+        // which, when rounded up, becomes
+        //     ceil(-log_γ(γ - 1))
+        //
+        // Putting it all together, the total number of buckets (assuming
+        // that limit is larger than the cutoff between buckets) is
+        //     ceil(-log_γ(γ - 1)) + ceil(log_γ(limit) - log_γ(γ - 1)) + 1
+        //
+        // This is mostly what the below code does with some exceptions
+        // for handling limits below the cutoff.
+
+        let gamma = (1.0 + alpha) / (1.0 - alpha);
+        let log_gamma_m1 = (gamma - 1.0).log(gamma);
+        let log_limit = (limit as f64).log(gamma).ceil();
+
+        let cutoff = (-log_gamma_m1).ceil();
+        let rest = ((limit as f64).log(gamma) - log_gamma_m1).ceil();
+
+        // Note: We keep two extra buckets
+        //  - one for 0
+        //  - one for values above the limit
+        let mut num_buckets = if log_limit <= cutoff {
+            log_limit as usize + 2
+        } else {
+            cutoff as usize + rest as usize + 2
+        };
+
+        if limit == std::u64::MAX {
+            // Don't need an overflow bucket if the entire range
+            // is covered.
+            num_buckets -= 1;
+        }
+
+        // Need to keep the maximum exponent less than std::i32::MAX
+        // since powi takes an i32.
+        assert!(
+            log_limit <= std::i32::MAX as f64,
+            "Sketch would use too many buckets - try decreasing the required precision"
+        );
+
+        let mut buckets = Vec::new();
+        buckets.resize_with(num_buckets, Default::default);
+
+        Self {
+            buckets,
+            gamma,
+            cutoff: cutoff as usize + 1,
+
+            count: AtomicU64::new(0),
+            limit,
+            min: AtomicU64::new(std::u64::MAX),
+            max: AtomicU64::new(std::u64::MIN),
+        }
+    }
+
+    /// Create a sketch that can store any `u64` with a relative
+    /// precision of `alpha`.
+    ///
+    /// # Panics
+    /// Panics if `alpha` is not in the range `(0, 1)` or if
+    /// *log<sub>(1 + alpha)/(1 - alpha)</sub>(std::u64::MAX)* is greater
+    /// than `std::i32::MAX`.
+    pub fn new(alpha: f64) -> Self {
+        Self::with_limit(std::u64::MAX, alpha)
+    }
+
+    /// The number of buckets in the sketch.
+    pub fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Get the bucket-index of a value.
+    fn index_of(&self, value: u64) -> usize {
+        match value {
+            x if x > self.limit => self.buckets.len() - 1,
+            x if x < self.cutoff as u64 => x as usize,
+            x => (x as f64).log(self.gamma).ceil() as usize + 1,
+        }
+    }
+
+    /// Increment the bucket holding `value` by `count`.
+    pub fn increment(&self, value: u64, count: <T as AtomicPrimitive>::Primitive) {
+        atomic_max(&self.max, value);
+        atomic_min(&self.min, value);
+        self.count.saturating_add(count.into());
+
+        self.buckets[self.index_of(value)].saturating_add(count);
+    }
+
+    /// Clear all buckets within the sketch.
+    pub fn clear(&self) {
+        for bucket in self.buckets.iter() {
+            bucket.set(Default::default());
+        }
+    }
+
+    /// Total count of samples in the sketch.
+    pub fn count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    /// The number of samples that were over the limit and are too
+    /// high to store in any given bucket.
+    pub fn too_high(&self) -> u64 {
+        if self.limit == std::u64::MAX {
+            return 0;
+        }
+
+        self.buckets.last().unwrap().get().into()
+    }
+
+    /// Returns the approximate value of the quantile specified from
+    /// 0.0 to 1.0.
+    ///
+    /// Any value returned that is within the range [0, limit] will be
+    /// accurate within a relative error of `alpha` provided that no
+    /// counters within the sketch have saturated.
+    ///
+    /// If those two conditions are not met, then no error bounds are
+    /// given for the returned quantile.
+    pub fn quantile(&self, q: f64) -> u64 {
+        if q.is_nan() {
+            return 0;
+        }
+
+        let min = self.min.load(Ordering::Relaxed);
+        let max = self.max.load(Ordering::Relaxed);
+
+        if q < 0.0 {
+            return min;
+        }
+        if q >= 1.0 {
+            return max;
+        }
+
+        let rank = (q * self.count() as f64) as u64;
+        let index = self
+            .buckets
+            .iter()
+            .scan(0u64, |total, count| {
+                *total += count.load(Ordering::Relaxed).into();
+                Some(*total)
+            })
+            .enumerate()
+            .skip_while(|&(_, count)| count <= rank)
+            .map(|(i, _)| i)
+            .next();
+
+        let index = match index {
+            Some(idx) if idx < self.cutoff => idx,
+            Some(idx) if idx == self.buckets.len() - 1 => return max,
+            Some(idx) => idx - 1,
+            None => return max,
+        };
+
+        ((self.gamma.powi(index as i32) / (0.5 * (self.gamma + 1.0))).round() as u64)
+            .min(max)
+            .max(min)
+    }
+
+    /// Merge two different sketches.
+    ///
+    /// # Panics
+    /// This function will panic if the number of buckets is
+    /// different between the two sketches.
+    pub fn merge(&self, other: &Self) {
+        assert_eq!(
+            self.buckets.len(),
+            other.buckets.len(),
+            "Attempted to merge differently-sized DDSketches"
+        );
+
+        self.count.saturating_add(other.count());
+        atomic_min(&self.min, other.min.load(Ordering::Relaxed));
+        atomic_max(&self.max, other.max.load(Ordering::Relaxed));
+
+        self.buckets
+            .iter()
+            .zip(other.buckets.iter())
+            .for_each(|(x, y)| {
+                x.saturating_add(y.load(Ordering::Relaxed));
+            });
+    }
+}
+
+fn atomic_max(atomic: &AtomicU64, value: u64) {
+    let mut existing = atomic.load(Ordering::Relaxed);
+    while existing < value {
+        existing = atomic.compare_and_swap(existing, value, Ordering::Relaxed);
+    }
+}
+fn atomic_min(atomic: &AtomicU64, value: u64) {
+    let mut existing = atomic.load(Ordering::Relaxed);
+    while existing > value {
+        existing = atomic.compare_and_swap(existing, value, Ordering::Relaxed);
+    }
+}

--- a/datastructures/src/ddsketch/atomic.rs
+++ b/datastructures/src/ddsketch/atomic.rs
@@ -3,6 +3,7 @@ use crate::counter::{Counter, Saturating, Unsigned};
 use atomics::{AtomicPrimitive, AtomicU64, Ordering};
 
 /// An atomic DDSketch.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AtomicDDSketch<T = AtomicU64>
 where
     T: Counter + Unsigned,

--- a/datastructures/src/ddsketch/dense.rs
+++ b/datastructures/src/ddsketch/dense.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 /// 
 /// This implementation should be preferred over `AtomicDDSketch`
 /// when concurrent insertion into the sketch is not needed.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DenseDDSketch<T = u64> {
     buckets: Vec<T>,
 

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -1,5 +1,7 @@
 //! Different implementations of DDSketch.
 
 mod atomic;
+mod dense;
 
-pub use self::atomic::DDSketch;
+pub use self::atomic::AtomicDDSketch;
+pub use self::dense::DenseDDSketch;

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -1,0 +1,5 @@
+//! Different implementations of DDSketch.
+
+mod atomic;
+
+pub use self::atomic::DDSketch;

--- a/datastructures/src/histogram/mod.rs
+++ b/datastructures/src/histogram/mod.rs
@@ -23,6 +23,7 @@ type SharedVecDeque<T> = Arc<Mutex<VecDeque<T>>>;
 /// the user to customize the `Histogram` to trade-off between being able to
 /// hold larger counts per `Bucket` or use less memory by selecting which type
 /// to use for the counters.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Histogram<T>
 where
     T: Counter + Unsigned,
@@ -34,8 +35,11 @@ where
     index: Vec<AtomicU64>,
     too_high: AtomicU64,
     precision: AtomicU32,
+    #[serde(skip)]
     samples: Option<SharedVecDeque<Sample<<T as AtomicPrimitive>::Primitive>>>,
+    #[serde(skip)]
     window: Option<Arc<Mutex<Duration>>>,
+    #[serde(skip)]
     capacity: Option<AtomicUsize>,
 }
 

--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -6,11 +6,16 @@
 
 #![deny(clippy::all)]
 
+
+#[macro_use]
+#[cfg(feature = "serde")]
+extern crate serde;
+
 pub use atomics::*;
 
 mod buffer;
 mod counter;
-pub mod ddsketch;
+mod ddsketch;
 mod heatmap;
 mod histogram;
 
@@ -18,3 +23,4 @@ pub use crate::buffer::*;
 pub use crate::counter::*;
 pub use crate::heatmap::*;
 pub use crate::histogram::*;
+pub use crate::ddsketch::*;

--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -10,6 +10,7 @@ pub use atomics::*;
 
 mod buffer;
 mod counter;
+pub mod ddsketch;
 mod heatmap;
 mod histogram;
 

--- a/latencygraph/Cargo.toml
+++ b/latencygraph/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "latencygraph"
+version = "0.1.0"
+authors = ["Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+datastructures = { path="../datastructures", features = [ "serde" ] }
+atomics = { path="../atomics" }
+
+plotters = "0.2"
+superslice = "1.0"
+serde_json = "1.0"

--- a/latencygraph/src/lib.rs
+++ b/latencygraph/src/lib.rs
@@ -1,0 +1,693 @@
+#![allow(deprecated)]
+
+use plotters::coord::AsRangedCoord;
+use plotters::prelude::*;
+
+use superslice::Ext as _;
+
+use atomics::AtomicU64;
+use datastructures::AtomicDDSketch;
+
+use std::error::Error;
+use std::ffi::OsStr;
+use std::marker::PhantomData;
+
+mod scales;
+
+pub use scales::*;
+
+macro_rules! hexcolour {
+    ($colour:literal) => {
+        RGBColor(
+            (($colour & 0xFF0000) >> 16) as u8,
+            (($colour & 0x00FF00) >> 8) as u8,
+            (($colour & 0x0000FF) >> 0) as u8,
+        )
+    };
+}
+
+const COLOURS: &[RGBColor] = &[
+    hexcolour!(0xAA0000),
+    hexcolour!(0x0000FF),
+    hexcolour!(0x888888),
+    hexcolour!(0xDDCC77),
+    hexcolour!(0x999933),
+    hexcolour!(0x332288),
+    hexcolour!(0x117733),
+    hexcolour!(0x88CCEE),
+    hexcolour!(0x882255),
+    hexcolour!(0x44AA99),
+    hexcolour!(0xAA4499),
+    hexcolour!(0xCC6677),
+];
+
+pub fn plot_linear(
+    sketch1: &AtomicDDSketch<AtomicU64>,
+    sketch2: &AtomicDDSketch<AtomicU64>,
+) -> Result<(), Box<dyn Error>> {
+    let mut quantiles: Vec<_> = (1..10000).map(|x| x as f64 / 10000.0).rev().collect();
+
+    quantiles.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+    let p995 = sketch1.quantile(0.995).max(sketch2.quantile(0.995)) as f64 / 1000.0;
+
+    let root = BitMapBackend::new("linear.png", (1920, 1080)).into_drawing_area();
+    root.fill(&WHITE)?;
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption("Pelikan-Twemcache Latency Distribution", ("Arial", 40))
+        .margin(20)
+        .set_label_area_size(LabelAreaPosition::Left, 100)
+        .set_label_area_size(LabelAreaPosition::Bottom, 40)
+        .build_ranged(0.0..1.0, 0.0..p995)?;
+
+    chart
+        .configure_mesh()
+        .y_desc("Latency (in µs)")
+        .x_desc("Quantile")
+        .x_label_style(("Arial", 20))
+        .y_label_style(("Arial", 20))
+        .draw()?;
+
+    let series = quantiles.iter().map(|&x| (x, sketch1.quantile(x) as f64 / 1000.0));
+    chart
+        .draw_series(LineSeries::new(series, COLOURS[0].stroke_width(2)))?
+        .label("C")
+        .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &COLOURS[0]));
+
+    let series = quantiles.iter().map(|&x| (x, sketch2.quantile(x) as f64 / 1000.0));
+    chart
+        .draw_series(LineSeries::new(series, COLOURS[1].stroke_width(2)))?
+        .label("Rust")
+        .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &COLOURS[1]));
+
+    chart
+        .configure_series_labels()
+        .background_style(WHITE.filled())
+        .draw()?;
+
+    Ok(())
+}
+
+fn lerp(a: f64, b: f64, f: f64) -> f64 {
+    a * (1.0 - f) + b * f
+}
+
+pub fn plot_log(
+    sketch1: &AtomicDDSketch<AtomicU64>,
+    sketch2: &AtomicDDSketch<AtomicU64>,
+) -> Result<(), Box<dyn Error>> {
+    let offset = 0.00009f64;
+    let start = offset.ln();
+    let end = (0.5f64).ln();
+
+    let mut quantiles: Vec<_> = (1..=10000)
+        .map(|x| x as f64 / 10000.0)
+        .map(|x| 1.0 - lerp(start, end, x).exp())
+        .rev()
+        .collect();
+
+    quantiles.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+    let max1 = sketch1.quantile(1.0) as f64 / 1000.0;
+    let max2 = sketch2.quantile(1.0) as f64 / 1000.0;
+    let max = max1.max(max2);
+    let p50 = sketch1.quantile(0.5).min(sketch2.quantile(0.5)) as f64 / 1000.0;
+
+    let root = BitMapBackend::new("log.png", (1920, 1080)).into_drawing_area();
+    root.fill(&WHITE)?;
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption("Pelikan-Twemcache Latency Tail", ("Arial", 40))
+        .margin(20)
+        .set_label_area_size(LabelAreaPosition::Left, 100)
+        .set_label_area_size(LabelAreaPosition::Bottom, 40)
+        .build_ranged(InvLogCoord::new(offset), LogRange(p50 * 0.8..max * 1.5))?;
+
+    chart
+        .configure_mesh()
+        .y_desc("Latency (in µs)")
+        .x_desc("Quantile")
+        .x_label_style(("Arial", 20))
+        .y_label_style(("Arial", 20))
+        .draw()?;
+
+    let series = quantiles.iter().map(|&x| (x, sketch1.quantile(x) as f64 / 1000.0));
+    chart
+        .draw_series(LineSeries::new(series, COLOURS[0].stroke_width(2)))?
+        .label("C")
+        .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &COLOURS[0]));
+
+    let series = quantiles.iter().map(|&x| (x, sketch2.quantile(x) as f64 / 1000.0));
+    chart
+        .draw_series(LineSeries::new(series, COLOURS[1].stroke_width(2)))?
+        .label("Rust")
+        .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &COLOURS[1]));
+
+    chart
+        .configure_series_labels()
+        .background_style(WHITE.filled())
+        .draw()?;
+
+    Ok(())
+}
+
+
+pub trait Summary {
+    fn quantile(&self, q: f64) -> f64;
+}
+
+pub trait Digest {
+    fn new() -> Self;
+
+    fn add_data<I>(&mut self, data: I)
+    where
+        I: Iterator<Item = f64>;
+
+    type Summary: Summary;
+    type Param;
+
+    fn summarize(&self, param: &Self::Param) -> Self::Summary;
+}
+
+pub fn read_data(file: &str) -> Vec<f64> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    let file = File::open(file).expect("Unable to open the file");
+    let mut reader = BufReader::new(file);
+
+    let mut res = vec![];
+    let mut buf = String::new();
+
+    let mut line = 0;
+    while reader
+        .read_line(&mut buf)
+        .expect(&format!("Error at line {}", line))
+        != 0
+    {
+        let val = buf
+            .trim()
+            .parse()
+            .expect(&format!("File contained invalid number at line {}", line));
+
+        res.push(val);
+        buf.clear();
+        line += 1;
+    }
+
+    res
+}
+
+fn exact_quantile(q: f64, data: &[f64]) -> f64 {
+    let index = (q * data.len() as f64) as usize;
+    data[index.min(data.len() - 1).max(0)]
+}
+
+fn exact_rank(val: f64, data: &[f64]) -> usize {
+    data.upper_bound_by(|x| x.partial_cmp(&val).unwrap())
+}
+fn exact_rank_min(val: f64, data: &[f64]) -> usize {
+    (data.lower_bound_by(|x| x.partial_cmp(&val).unwrap()) + 1).min(data.len())
+}
+
+fn absdiff(x: usize, y: usize) -> usize {
+    let max = x.max(y);
+    let min = x.min(y);
+
+    max - min
+}
+
+fn log_interp2(pt: f64, min: f64, max: f64) -> f64 {
+    min.powf(pt) * max.powf(1.0 - pt)
+}
+
+fn double_log_interp(pt: f64, min: f64, max: f64) -> f64 {
+    let mid = (min + max) / 2.0;
+    if pt > 0.5 {
+        log_interp2((1.0 - pt) * 2.0, max, mid)
+    } else {
+        log_interp2(pt * 2.0, mid, min)
+    }
+}
+
+pub struct PlotConfig<'data, D> {
+    x_desc: String,
+    y_desc: String,
+    caption: String,
+    data_label: String,
+    size: (u32, u32),
+
+    data: &'data [f64],
+
+    _marker: PhantomData<D>,
+}
+
+impl<'d, D: Digest> PlotConfig<'d, D> {
+    pub fn new(data: &'d [f64]) -> Self {
+        Self {
+            x_desc: "quantile".to_owned(),
+            y_desc: String::new(),
+            caption: String::new(),
+            data_label: String::new(),
+            size: (1080, 720),
+
+            data,
+
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn caption(&mut self, caption: impl AsRef<str>) -> &mut Self {
+        self.caption = caption.as_ref().to_owned();
+        self
+    }
+
+    pub fn data_label(&mut self, label: impl AsRef<str>) -> &mut Self {
+        self.data_label = label.as_ref().to_owned();
+        self
+    }
+
+    pub fn x_desc(&mut self, x_desc: impl AsRef<str>) -> &mut Self {
+        self.x_desc = x_desc.as_ref().to_owned();
+        self
+    }
+
+    pub fn y_desc(&mut self, y_desc: impl AsRef<str>) -> &mut Self {
+        self.y_desc = y_desc.as_ref().to_owned();
+        self
+    }
+
+    pub fn size(&mut self, size: (u32, u32)) -> &mut Self {
+        self.size = size;
+        self
+    }
+
+    fn quantiles(&self) -> Vec<f64> {
+        let mut quantiles: Vec<_> = (1..10000)
+            .map(|x| x as f64 / 10000.0)
+            .map(|x| 1.0 - double_log_interp(x, 0.0001, 0.9999))
+            .rev()
+            .collect();
+
+        quantiles.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+        quantiles
+    }
+
+    pub fn plot_values<X, Y, XR, YR, L>(
+        &mut self,
+        x_axis: X,
+        y_axis: Y,
+        filename: impl AsRef<OsStr>,
+        estimates: &[D::Param],
+        mut label_fn: impl FnMut(&D::Param) -> L,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* min: */ f64, /* max: */ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        L: AsRef<str>,
+    {
+        let mut sorted = self.data.to_vec();
+        sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+        let quantiles = self.quantiles();
+
+        let root = BitMapBackend::new(filename.as_ref(), self.size).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let min = *sorted.first().unwrap();
+        let max = *sorted.last().unwrap();
+
+        let mut chart = ChartBuilder::on(&root)
+            .caption(&self.caption, ("Arial", 40))
+            .margin(20)
+            .set_label_area_size(LabelAreaPosition::Left, 100)
+            .set_label_area_size(LabelAreaPosition::Bottom, 40)
+            .build_ranged(x_axis(), y_axis(min, max))?;
+
+        chart
+            .configure_mesh()
+            .y_desc(&self.y_desc)
+            .x_desc(&self.x_desc)
+            .draw()?;
+
+        let values = quantiles
+            .iter()
+            .copied()
+            .map(|x| (x, exact_quantile(x, &sorted) as f64));
+
+        let mut digest = D::new();
+        digest.add_data(self.data.iter().copied());
+
+        for (i, param) in estimates.iter().enumerate() {
+            let summary = digest.summarize(param);
+
+            let series = quantiles.iter().copied().map(|x| (x, summary.quantile(x)));
+
+            chart
+                .draw_series(LineSeries::new(series, COLOURS[i].stroke_width(2)))?
+                .label(label_fn(param).as_ref())
+                .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &COLOURS[i]));
+        }
+
+        chart
+            .draw_series(LineSeries::new(values, BLACK.stroke_width(2)))?
+            .label(&self.data_label)
+            .legend(move |(x, y)| Path::new(vec![(x, y), (x + 20, y)], &BLACK));
+
+        chart
+            .configure_series_labels()
+            .background_style(WHITE.filled())
+            .draw()?;
+
+        Ok(self)
+    }
+
+    pub fn plot_errors<X, Y, XR, YR>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+        mut err_fn: impl FnMut(
+            /*q:*/ f64,
+            /*sorted:*/ &[f64],
+            /*summary:*/ &D::Summary,
+        ) -> f64,
+        into_percent: bool,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error: */ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+    {
+        let mut sorted = self.data.to_vec();
+        sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+        let root = BitMapBackend::new(filename.as_ref(), self.size).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let quantiles = self.quantiles();
+
+        let mut digest = D::new();
+        digest.add_data(self.data.iter().copied());
+
+        let summary = digest.summarize(param);
+
+        let mut max_err = 0.0;
+        let mult = if into_percent { 100.0 } else { 1.0 };
+
+        let values: Vec<_> = quantiles
+            .iter()
+            .copied()
+            .map(|q| {
+                let err = err_fn(q, &sorted, &summary);
+
+                if err > max_err {
+                    max_err = err;
+                }
+
+                Circle::new((q, err * mult), 3, BLACK.filled())
+            })
+            .collect();
+
+        let mut chart = ChartBuilder::on(&root)
+            .caption(&self.caption, ("Arial", 40))
+            .margin(20)
+            .set_label_area_size(LabelAreaPosition::Left, 60)
+            .set_label_area_size(LabelAreaPosition::Bottom, 40)
+            .build_ranged(x_axis_fn(), y_axis_fn(max_err * mult))?;
+
+        chart
+            .configure_mesh()
+            .y_desc(&self.y_desc)
+            .x_desc(&self.x_desc)
+            .draw()?;
+
+        chart
+            .draw_series(values)?
+            .label(&self.data_label)
+            .legend(|(x, y)| Path::new(vec![(x, y), (x + 20, y)], &BLACK));
+
+        chart
+            .configure_series_labels()
+            .background_style(WHITE.filled())
+            .draw()?;
+        Ok(self)
+    }
+
+    pub fn plot_rank_errors<X, Y, XR, YR>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error: */ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+    {
+        self.plot_errors(
+            x_axis_fn,
+            y_axis_fn,
+            filename,
+            param,
+            |q, sorted, summary| {
+                let exact = exact_quantile(q, &sorted);
+                let approx = summary.quantile(q);
+
+                let approx_rank_max = exact_rank(approx, &sorted);
+                let approx_rank_min = exact_rank_min(approx, &sorted);
+                let exact_rank = exact_rank(exact, &sorted);
+
+                let rank_err =
+                    absdiff(exact_rank, approx_rank_max).min(absdiff(exact_rank, approx_rank_min));
+
+                rank_err as f64 / sorted.len() as f64
+            },
+            true,
+        )
+    }
+
+    pub fn plot_rel_value_errors<X, Y, XR, YR>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error: */ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+    {
+        self.plot_errors(
+            x_axis_fn,
+            y_axis_fn,
+            filename,
+            param,
+            |q, sorted, summary| {
+                let exact = exact_quantile(q, &sorted);
+                let approx = summary.quantile(q);
+
+                let val_err = (exact - approx).abs();
+
+                if exact == approx {
+                    0.0
+                } else {
+                    val_err as f64 / exact as f64
+                }
+            },
+            true,
+        )
+    }
+
+    pub fn plot_abs_value_errors<X, Y, XR, YR>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error: */ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+    {
+        self.plot_errors(
+            x_axis_fn,
+            y_axis_fn,
+            filename,
+            param,
+            |q, sorted, summary| {
+                let exact = exact_quantile(q, &sorted);
+                let approx = summary.quantile(q);
+
+                (exact - approx).abs()
+            },
+            false,
+        )
+    }
+
+    pub fn plot_errors_and_values<X, Y, XR, YR, L>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+        mut err_fn: impl FnMut(
+            /*q:*/ f64,
+            /*sorted:*/ &[f64],
+            /*summary:*/ &D::Summary,
+        ) -> f64,
+        error_label: impl AsRef<str>,
+        into_percent: bool,
+        mut label_fn: impl FnMut(&D::Param) -> L,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error:*/ f64, /*max:*/ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        L: AsRef<str>,
+    {
+        let mut sorted = self.data.to_vec();
+        sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+
+        let root = BitMapBackend::new(filename.as_ref(), self.size).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let quantiles = self.quantiles();
+
+        let mut digest = D::new();
+        digest.add_data(self.data.iter().copied());
+
+        let summary = digest.summarize(param);
+
+        let mut max_err = 0.0;
+        let mult = if into_percent { 100.0 } else { 1.0 };
+
+        let errors: Vec<_> = quantiles
+            .iter()
+            .copied()
+            .map(|q| {
+                let err = err_fn(q, &sorted, &summary);
+
+                if err > max_err {
+                    max_err = err;
+                }
+
+                (q, err * mult)
+            })
+            .collect();
+
+        let values: Vec<_> = quantiles
+            .iter()
+            .copied()
+            .map(|q| (q, exact_quantile(q, &sorted)))
+            .collect();
+        let estimates: Vec<_> = quantiles
+            .iter()
+            .copied()
+            .map(|q| (q, summary.quantile(q)))
+            .collect();
+
+        let max = *sorted.last().unwrap();
+
+        let mut chart = ChartBuilder::on(&root)
+            .caption(&self.caption, ("Arial", 40))
+            .margin(20)
+            .set_label_area_size(LabelAreaPosition::Left, 60)
+            .set_label_area_size(LabelAreaPosition::Bottom, 40)
+            .build_ranged(x_axis_fn(), y_axis_fn(max_err * mult, max))?;
+
+        chart
+            .configure_mesh()
+            .y_desc(&self.y_desc)
+            .x_desc(&self.x_desc)
+            .draw()?;
+
+        chart.draw_series(LineSeries::new(errors.iter().copied(), RED.stroke_width(1)))?;
+
+        chart
+            .draw_series(AreaSeries::new(errors, 0.0, &RED.mix(0.2)))?
+            .label(error_label.as_ref())
+            .legend(|(x, y)| Path::new(vec![(x, y), (x + 20, y)], &RED));
+
+        chart
+            .draw_series(LineSeries::new(values, BLACK.stroke_width(2)))?
+            .label(&self.data_label)
+            .legend(|(x, y)| Path::new(vec![(x, y), (x + 20, y)], &BLACK));
+
+        chart
+            .draw_series(LineSeries::new(estimates, BLUE.stroke_width(2)))?
+            .label(label_fn(&param).as_ref())
+            .legend(|(x, y)| Path::new(vec![(x, y), (x + 20, y)], &BLUE));
+
+        chart
+            .configure_series_labels()
+            .background_style(&WHITE.mix(0.8))
+            .border_style(&BLACK)
+            .position(SeriesLabelPosition::UpperLeft)
+            .draw()?;
+
+        Ok(self)
+    }
+
+    pub fn plot_abs_errors_and_vals<X, Y, XR, YR, L>(
+        &mut self,
+        x_axis_fn: X,
+        y_axis_fn: Y,
+        filename: impl AsRef<OsStr>,
+        param: &D::Param,
+        error_label: impl AsRef<str>,
+        label_fn: impl FnMut(&D::Param) -> L,
+    ) -> Result<&mut Self, Box<dyn Error>>
+    where
+        X: FnOnce() -> XR,
+        Y: FnOnce(/* max_error:*/ f64, /*max:*/ f64) -> YR,
+        XR: AsRangedCoord<Value = f64>,
+        YR: AsRangedCoord<Value = f64>,
+        <XR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        <YR as AsRangedCoord>::CoordDescType: Ranged<ValueType = f64>,
+        L: AsRef<str>,
+    {
+        self.plot_errors_and_values(
+            x_axis_fn,
+            y_axis_fn,
+            filename,
+            param,
+            |q, sorted, summary| {
+                let exact = exact_quantile(q, sorted);
+                let approx = summary.quantile(q);
+
+                (exact - approx).abs()
+            },
+            error_label,
+            false,
+            label_fn,
+        )?;
+
+        Ok(self)
+    }
+}

--- a/latencygraph/src/main.rs
+++ b/latencygraph/src/main.rs
@@ -1,0 +1,16 @@
+
+use latencygraph::*;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+
+    let mut file = std::fs::File::open(args.next().unwrap()).unwrap();
+    let sketch1 = serde_json::from_reader(&mut file).unwrap();
+
+    let mut file = std::fs::File::open(args.next().unwrap()).unwrap();
+    let sketch2 = serde_json::from_reader(&mut file).unwrap();
+
+    plot_linear(&sketch1, &sketch2).unwrap();
+    plot_log(&sketch1, &sketch2).unwrap();
+}
+

--- a/latencygraph/src/scales.rs
+++ b/latencygraph/src/scales.rs
@@ -1,0 +1,142 @@
+
+use plotters::prelude::*;
+use plotters::coord::AsRangedCoord;
+
+pub struct InvLogCoord {
+    range: LogCoord<f64>
+}
+
+impl InvLogCoord {
+    pub fn new(off: f64) -> Self {
+        Self {
+            range: LogRange(off .. 0.5).into()
+        }
+    }
+}
+
+impl Ranged for InvLogCoord {
+    type ValueType = f64;
+
+    fn map(&self, value: &f64, limit: (i32, i32)) -> i32 {        
+        limit.1 - self.range.map(&(1.0 - *value), limit) + limit.0
+    }
+    
+    fn key_points(&self, max_points: usize) -> Vec<f64> {
+        let mut points = self.range.key_points(max_points - 1);
+        points.push(0.5);
+
+        for point in points.iter_mut() {
+            *point = 1.0 - *point;
+        }
+
+        points
+    }
+
+    fn range(&self) -> std::ops::Range<f64> {
+        0.5 .. 1.0
+    }
+}
+
+impl AsRangedCoord for InvLogCoord {
+    type CoordDescType = Self;
+    type Value = f64;
+}
+
+pub struct DoubleLogCoord {
+    lower: LogCoord<f64>,
+    upper: LogCoord<f64>,
+}
+
+impl DoubleLogCoord {
+    pub fn new(bot: f64, top: f64) -> Self {
+        Self {
+            lower: LogRange(bot..0.5).into(),
+            upper: LogRange((1.0 - top)..0.5).into(),
+        }
+    }
+}
+
+impl Ranged for DoubleLogCoord {
+    type ValueType = f64;
+
+    fn map(&self, value: &f64, limit: (i32, i32)) -> i32 {
+        if *value > 0.5 {
+            let offset = self
+                .upper
+                .map(&(1.0 - value), (limit.0 + (limit.1 - limit.0) / 2, limit.1));
+
+            limit.1 - (offset - limit.0) + (limit.1 - limit.0) / 2
+        } else {
+            self.lower
+                .map(value, (limit.0, limit.1 - (limit.1 - limit.0) / 2))
+        }
+    }
+
+    fn key_points(&self, max_points: usize) -> Vec<f64> {
+        let mut lower = self.lower.key_points(max_points / 2);
+        lower.extend(
+            self.upper
+                .key_points(max_points / 2)
+                .into_iter()
+                .rev()
+                .map(|x| (1.0 - x))
+                .chain(std::iter::once(0.5)),
+        );
+
+        lower
+    }
+
+    fn range(&self) -> std::ops::Range<f64> {
+        0.0..1.0
+    }
+}
+
+impl AsRangedCoord for DoubleLogCoord {
+    type CoordDescType = Self;
+    type Value = f64;
+}
+
+pub struct PlusOneRange<R>(pub R)
+where
+    R: AsRangedCoord<Value = f64>;
+
+impl<R> AsRangedCoord for PlusOneRange<R>
+where
+    R: AsRangedCoord<Value = f64>,
+    R::CoordDescType: Ranged<ValueType = f64>
+{
+    type CoordDescType = PlusOneCoord<R::CoordDescType>;
+    type Value = f64;
+}
+
+impl<R> From<PlusOneRange<R>> for PlusOneCoord<R::CoordDescType>
+where
+    R: AsRangedCoord<Value = f64>,
+    R::CoordDescType: Ranged<ValueType = f64>
+{
+    fn from(x: PlusOneRange<R>) -> PlusOneCoord<R::CoordDescType> {
+        PlusOneCoord(x.0.into())
+    }
+}
+
+pub struct PlusOneCoord<C>(pub C)
+where
+    C: Ranged;
+
+impl<C: Ranged<ValueType = f64>> Ranged for PlusOneCoord<C> {
+    type ValueType = f64;
+
+    fn map(&self, value: &f64, limit: (i32, i32)) -> i32 {
+        self.0.map(&(*value + 1.0), limit)
+    }
+
+    fn key_points(&self, max_points: usize) -> Vec<f64> {
+        self.0.key_points(max_points)
+    }
+
+    fn range(&self) -> std::ops::Range<f64> {
+        let r = self.0.range();
+
+        r.start - 1.0 .. r.end - 1.0
+    }
+} 

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -11,13 +11,16 @@ publish = false
 
 [dependencies]
 atomics = { path = "../atomics" }
-datastructures = { path = "../datastructures" }
+datastructures = { path = "../datastructures", features = [ "serde" ] }
 dejavu = "2.37.0"
 hsl = "0.1.1"
 logger = { path = "../logger" }
 png = "0.15.0"
 rusttype = "0.8.1"
 time = "0.1.42"
+
+serde = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/waterfall/src/lib.rs
+++ b/waterfall/src/lib.rs
@@ -8,11 +8,26 @@ use datastructures::*;
 use hsl::HSL;
 use logger::*;
 use rusttype::{point, FontCollection, PositionedGlyph, Scale};
+use serde::Serialize;
 
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
+
+pub fn save_summary<T>(
+    summary: &AtomicDDSketch<T>,
+    file: &str
+) where
+    T: Counter + Unsigned + Serialize,
+    <T as AtomicPrimitive>::Primitive: Default + PartialEq + Copy + Saturating,
+    u64: From<<T as AtomicPrimitive>::Primitive>,
+{
+
+    let mut json_file = std::fs::File::create(file.to_string() + ".json").unwrap();
+    serde_json::to_writer_pretty(&mut json_file, summary).unwrap();
+    
+}
 
 /// Render and save a waterfall from a `Heatmap` to a file. You can specify
 /// `labels` for the value axis. And spacing of labels on the time axis is


### PR DESCRIPTION
This replaces the waterfall workflow with dumping a serialized DDSketch instead. It's not meant to be integrated into rpc-perf proper but instead shows how rpc-perf can be used to generate latency graphs.

The graph generation parts within this PR are specialized to my end-of-internship presentation so they probably won't generalize to anything beyond comparing two latency distributions. However, it should be enough to show how to draw these graphs.
