### PR TITLE
Add DDSketch to rpc-perf

### DIFF
--- a/datastructures/src/ddsketch/atomic.rs
+++ b/datastructures/src/ddsketch/atomic.rs
@@ -1,3 +1,7 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use crate::counter::{Counter, Saturating, Unsigned};
 
 use atomics::{AtomicPrimitive, AtomicU64, Ordering};

--- a/datastructures/src/ddsketch/atomic.rs
+++ b/datastructures/src/ddsketch/atomic.rs
@@ -150,7 +150,7 @@ where
     }
 
     /// Clear all buckets within the sketch.
-    /// 
+    ///
     /// Note that clearing while other threads are inserting
     /// into the sketch is likely to leave it in a somewhat
     /// inconsistent state.
@@ -253,7 +253,7 @@ where
     }
 
     /// Get the approximate rank of `value` within the sketch.
-    /// 
+    ///
     /// For any given distribution this may be arbitrarily inaccurate depending
     /// on what fraction of the values in the sketch are mapped the same bucket.
     pub fn rank(&self, value: u64) -> u64 {

--- a/datastructures/src/ddsketch/atomic.rs
+++ b/datastructures/src/ddsketch/atomic.rs
@@ -1,0 +1,259 @@
+use crate::counter::{Counter, Saturating, Unsigned};
+
+use atomics::{AtomicPrimitive, AtomicU64, Ordering};
+
+/// An atomic DDSketch.
+pub struct DDSketch<T>
+where
+    T: Counter + Unsigned,
+    <T as AtomicPrimitive>::Primitive: Default + PartialEq + Copy + Saturating + Into<u64>,
+{
+    buckets: Vec<T>,
+
+    gamma: f64,
+    /// Number of linear-sized buckets before we switch to log sized buckets.
+    ///
+    /// This saves space since below a certain point log-sized buckets have a
+    /// width of less than 1 which is useless since we are storign integers.
+    cutoff: usize,
+
+    count: AtomicU64,
+    limit: u64,
+    min: AtomicU64,
+    max: AtomicU64,
+}
+
+impl<T> DDSketch<T>
+where
+    T: Counter + Unsigned,
+    <T as AtomicPrimitive>::Primitive: Default + PartialEq + Copy + Saturating + Into<u64>,
+{
+    /// Create a sketch that can store values up to `limit` with
+    /// a relative precision of `alpha`.
+    ///
+    /// # Panics
+    /// Panics if `alpha` is not in the range `(0, 1)` or if
+    /// *log<sub>(1 + alpha)/(1 - alpha)</sub>(limit)* is greater
+    /// than `std::i32::MAX`.
+    pub fn with_limit(limit: u64, alpha: f64) -> Self {
+        assert!(
+            alpha > 0.0 && alpha < 1.0,
+            "alpha must be in the range (0.0, 1.0)"
+        );
+
+        // Here's how the formula below works.
+        //
+        // First, to make the formulas shorter, define
+        //    γ = (1 + α) / (1 - α)
+        // This is the ratio between the maximum and minumum value
+        // within a bucket.
+        //
+        // So we want to figure out the number of buckets that we store
+        // within the sketch. The naive way to do this is to use
+        //     log_γ(limit) + 1
+        // buckets. (log_γ(limit) buckets between 1 and limit and 1 extra
+        // for zero.) However, this is wasteful since there will be a bunch
+        // of buckets near 1 that will have width smaller than 1 and so
+        // would be permanently empty. Instead, we'd like to have an exact
+        // histogram up to a certain number, then switch over to the log-sized
+        // histogram.
+        //
+        // The best point to do this is once the log-sized have a size of 1.
+        // This happens at index
+        //     log_γ (1 / (γ - 1)) = -log_γ(γ - 1)
+        // which, when rounded up, becomes
+        //     ceil(-log_γ(γ - 1))
+        //
+        // Putting it all together, the total number of buckets (assuming
+        // that limit is larger than the cutoff between buckets) is
+        //     ceil(-log_γ(γ - 1)) + ceil(log_γ(limit) - log_γ(γ - 1)) + 1
+        //
+        // This is mostly what the below code does with some exceptions
+        // for handling limits below the cutoff.
+
+        let gamma = (1.0 + alpha) / (1.0 - alpha);
+        let log_gamma_m1 = (gamma - 1.0).log(gamma);
+        let log_limit = (limit as f64).log(gamma).ceil();
+
+        let cutoff = (-log_gamma_m1).ceil();
+        let rest = ((limit as f64).log(gamma) - log_gamma_m1).ceil();
+
+        // Note: We keep two extra buckets
+        //  - one for 0
+        //  - one for values above the limit
+        let mut num_buckets = if log_limit <= cutoff {
+            log_limit as usize + 2
+        } else {
+            cutoff as usize + rest as usize + 2
+        };
+
+        if limit == std::u64::MAX {
+            // Don't need an overflow bucket if the entire range
+            // is covered.
+            num_buckets -= 1;
+        }
+
+        // Need to keep the maximum exponent less than std::i32::MAX
+        // since powi takes an i32.
+        assert!(
+            log_limit <= std::i32::MAX as f64,
+            "Sketch would use too many buckets - try decreasing the required precision"
+        );
+
+        let mut buckets = Vec::new();
+        buckets.resize_with(num_buckets, Default::default);
+
+        Self {
+            buckets,
+            gamma,
+            cutoff: cutoff as usize + 1,
+
+            count: AtomicU64::new(0),
+            limit,
+            min: AtomicU64::new(std::u64::MAX),
+            max: AtomicU64::new(std::u64::MIN),
+        }
+    }
+
+    /// Create a sketch that can store any `u64` with a relative
+    /// precision of `alpha`.
+    ///
+    /// # Panics
+    /// Panics if `alpha` is not in the range `(0, 1)` or if
+    /// *log<sub>(1 + alpha)/(1 - alpha)</sub>(std::u64::MAX)* is greater
+    /// than `std::i32::MAX`.
+    pub fn new(alpha: f64) -> Self {
+        Self::with_limit(std::u64::MAX, alpha)
+    }
+
+    /// The number of buckets in the sketch.
+    pub fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Get the bucket-index of a value.
+    fn index_of(&self, value: u64) -> usize {
+        match value {
+            x if x > self.limit => self.buckets.len() - 1,
+            x if x < self.cutoff as u64 => x as usize,
+            x => (x as f64).log(self.gamma).ceil() as usize + 1,
+        }
+    }
+
+    /// Increment the bucket holding `value` by `count`.
+    pub fn increment(&self, value: u64, count: <T as AtomicPrimitive>::Primitive) {
+        atomic_max(&self.max, value);
+        atomic_min(&self.min, value);
+        self.count.saturating_add(count.into());
+
+        self.buckets[self.index_of(value)].saturating_add(count);
+    }
+
+    /// Clear all buckets within the sketch.
+    pub fn clear(&self) {
+        for bucket in self.buckets.iter() {
+            bucket.set(Default::default());
+        }
+    }
+
+    /// Total count of samples in the sketch.
+    pub fn count(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    /// The number of samples that were over the limit and are too
+    /// high to store in any given bucket.
+    pub fn too_high(&self) -> u64 {
+        if self.limit == std::u64::MAX {
+            return 0;
+        }
+
+        self.buckets.last().unwrap().get().into()
+    }
+
+    /// Returns the approximate value of the quantile specified from
+    /// 0.0 to 1.0.
+    ///
+    /// Any value returned that is within the range [0, limit] will be
+    /// accurate within a relative error of `alpha` provided that no
+    /// counters within the sketch have saturated.
+    ///
+    /// If those two conditions are not met, then no error bounds are
+    /// given for the returned quantile.
+    pub fn quantile(&self, q: f64) -> u64 {
+        if q.is_nan() {
+            return 0;
+        }
+
+        let min = self.min.load(Ordering::Relaxed);
+        let max = self.max.load(Ordering::Relaxed);
+
+        if q < 0.0 {
+            return min;
+        }
+        if q >= 1.0 {
+            return max;
+        }
+
+        let rank = (q * self.count() as f64) as u64;
+        let index = self
+            .buckets
+            .iter()
+            .scan(0u64, |total, count| {
+                *total += count.load(Ordering::Relaxed).into();
+                Some(*total)
+            })
+            .enumerate()
+            .skip_while(|&(_, count)| count <= rank)
+            .map(|(i, _)| i)
+            .next();
+
+        let index = match index {
+            Some(idx) if idx < self.cutoff => idx,
+            Some(idx) if idx == self.buckets.len() - 1 => return max,
+            Some(idx) => idx - 1,
+            None => return max,
+        };
+
+        ((self.gamma.powi(index as i32) / (0.5 * (self.gamma + 1.0))).round() as u64)
+            .min(max)
+            .max(min)
+    }
+
+    /// Merge two different sketches.
+    ///
+    /// # Panics
+    /// This function will panic if the number of buckets is
+    /// different between the two sketches.
+    pub fn merge(&self, other: &Self) {
+        assert_eq!(
+            self.buckets.len(),
+            other.buckets.len(),
+            "Attempted to merge differently-sized DDSketches"
+        );
+
+        self.count.saturating_add(other.count());
+        atomic_min(&self.min, other.min.load(Ordering::Relaxed));
+        atomic_max(&self.max, other.max.load(Ordering::Relaxed));
+
+        self.buckets
+            .iter()
+            .zip(other.buckets.iter())
+            .for_each(|(x, y)| {
+                x.saturating_add(y.load(Ordering::Relaxed));
+            });
+    }
+}
+
+fn atomic_max(atomic: &AtomicU64, value: u64) {
+    let mut existing = atomic.load(Ordering::Relaxed);
+    while existing < value {
+        existing = atomic.compare_and_swap(existing, value, Ordering::Relaxed);
+    }
+}
+fn atomic_min(atomic: &AtomicU64, value: u64) {
+    let mut existing = atomic.load(Ordering::Relaxed);
+    while existing > value {
+        existing = atomic.compare_and_swap(existing, value, Ordering::Relaxed);
+    }
+}

--- a/datastructures/src/ddsketch/dense.rs
+++ b/datastructures/src/ddsketch/dense.rs
@@ -1,3 +1,7 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use crate::counter::Saturating;
 
 use std::convert::TryFrom;

--- a/datastructures/src/ddsketch/dense.rs
+++ b/datastructures/src/ddsketch/dense.rs
@@ -1,11 +1,10 @@
-
 use crate::counter::Saturating;
 
-use std::ops::AddAssign;
 use std::convert::TryFrom;
+use std::ops::AddAssign;
 
 /// A non-atomic DDSketch.
-/// 
+///
 /// This implementation should be preferred over `AtomicDDSketch`
 /// when concurrent insertion into the sketch is not needed.
 pub struct DenseDDSketch<T = u64> {
@@ -51,7 +50,7 @@ impl<T> DenseDDSketch<T> {
     }
 
     /// Maximum value that the sketch is sized to store.
-    /// 
+    ///
     /// Note that there is another bucket to catch values
     /// greater than this so they don't get lost, but there
     /// are no precision guarantees.
@@ -60,7 +59,7 @@ impl<T> DenseDDSketch<T> {
     }
 
     /// Indicates whether the sketch has no values within it.
-    /// 
+    ///
     /// This is the same as checking if `count() == 0`.
     pub fn is_empty(&self) -> bool {
         self.count() == 0
@@ -69,7 +68,7 @@ impl<T> DenseDDSketch<T> {
 
 impl<T> DenseDDSketch<T>
 where
-    T: Saturating + Default + PartialEq + Copy + Into<u64>
+    T: Saturating + Default + PartialEq + Copy + Into<u64>,
 {
     /// Create a sketch that can store values up to `limit` with
     /// a relative precision of `alpha`.
@@ -266,7 +265,7 @@ where
     }
 
     /// Get the approximate rank of `value` within the sketch.
-    /// 
+    ///
     /// For any given distribution this may be arbitrarily inaccurate depending
     /// on what fraction of the values in the sketch are mapped the same bucket.
     pub fn rank(&self, value: u64) -> u64 {
@@ -281,7 +280,7 @@ where
 
 fn saturating_inc<T>(loc: &mut T, val: T)
 where
-    T: Saturating
+    T: Saturating,
 {
     *loc = loc.saturating_add(val);
 }
@@ -289,7 +288,7 @@ where
 impl<T> Extend<u64> for DenseDDSketch<T>
 where
     T: Saturating + AddAssign<T> + Default + PartialEq + Copy + Into<u64> + TryFrom<u64>,
-    <T as TryFrom<u64>>::Error: std::fmt::Debug
+    <T as TryFrom<u64>>::Error: std::fmt::Debug,
 {
     fn extend<I: IntoIterator<Item = u64>>(&mut self, iter: I) {
         let one = T::try_from(1).expect("1 is not convertable to T");

--- a/datastructures/src/ddsketch/error.rs
+++ b/datastructures/src/ddsketch/error.rs
@@ -1,0 +1,60 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::fmt;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Empty {}
+
+/// Type of DDSketch error.
+///
+/// This enum is nonexhaustive and adding new variants
+/// is not considered to be a breaking change.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum DDSketchErrorKind {
+    InvalidAlpha,
+    TooManyBuckets,
+    Unmergeable,
+
+    // If we ever have more error conditions we can now
+    // add them without worrying about breaking backwards
+    // compatibility.
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+/// Error for when an operation with a DDSketch failed to complete.
+#[derive(Debug)]
+pub struct DDSketchError {
+    kind: DDSketchErrorKind,
+}
+
+impl DDSketchError {
+    pub(super) fn new(kind: DDSketchErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub fn kind(&self) -> DDSketchErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for DDSketchError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use self::DDSketchErrorKind::*;
+
+        match self.kind {
+            InvalidAlpha => write!(fmt, "Relative error bound outside the range (0, 1)"),
+            TooManyBuckets => write!(fmt, "DDSketch would use too many buckets"),
+            Unmergeable => write!(
+                fmt,
+                "Cannot merge sketches with different numbers of buckets"
+            ),
+
+            __Nonexhaustive(e) => match e {},
+        }
+    }
+}
+
+impl std::error::Error for DDSketchError {}

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -6,6 +6,8 @@
 
 mod atomic;
 mod dense;
+mod error;
 
 pub use self::atomic::AtomicDDSketch;
 pub use self::dense::DenseDDSketch;
+pub use self::error::{DDSketchError, DDSketchErrorKind};

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -1,5 +1,7 @@
 //! Different implementations of DDSketch.
 
 mod atomic;
+mod dense;
 
-pub use self::atomic::DDSketch;
+pub use self::atomic::AtomicDDSketch;
+pub use self::dense::DenseDDSketch;

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -1,0 +1,5 @@
+//! Different implementations of DDSketch.
+
+mod atomic;
+
+pub use self::atomic::DDSketch;

--- a/datastructures/src/ddsketch/mod.rs
+++ b/datastructures/src/ddsketch/mod.rs
@@ -1,3 +1,7 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 //! Different implementations of DDSketch.
 
 mod atomic;

--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -10,6 +10,7 @@ pub use atomics::*;
 
 mod buffer;
 mod counter;
+pub mod ddsketch;
 mod heatmap;
 mod histogram;
 

--- a/datastructures/src/lib.rs
+++ b/datastructures/src/lib.rs
@@ -10,11 +10,12 @@ pub use atomics::*;
 
 mod buffer;
 mod counter;
-pub mod ddsketch;
+mod ddsketch;
 mod heatmap;
 mod histogram;
 
 pub use crate::buffer::*;
 pub use crate::counter::*;
+pub use crate::ddsketch::*;
 pub use crate::heatmap::*;
 pub use crate::histogram::*;


### PR DESCRIPTION
This adds two variants of DDSketch to the datastructures crate:
- DenseDDSketch - a non thread-safe version of DDSketch
- AtomicDDSketch - a dense ddsketch using atomic counters instead that can be shared across threads

I haven't had time to write a sparse version of ddsketch that would be suitable for inclusion in rpc-perf, hopefully I'll get some time to work on this later along with versions of the moments-sketch and q-digest.