### PR TITLE
simplify cargo build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,28 +13,12 @@ members = [
     "waterfall",
 ]
 
-[profile.dev]
-opt-level = 0
-debug = true
-rpath = false
-lto = false
-debug-assertions = true
-codegen-units = 1
-
 [profile.bench]
-opt-level = 3
 debug = true
-rpath = false
 lto = true
-debug-assertions = false
 codegen-units = 1
-incremental = false
 
 [profile.release]
-opt-level = 3
 debug = true
-rpath = false
 lto = true
-debug-assertions = false
 codegen-units = 1
-incremental = false


### PR DESCRIPTION
Reduce the cargo build profiles to the minimum set of overrides for
the behaviors we want.
