### PR TITLE
rpc-perf: fix timeout stats and waterfall

### DIFF
--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -76,6 +76,7 @@ pub fn main() {
         let current = metrics.readings();
         let mut readings = readings.lock().unwrap();
         *readings = current;
+        metrics.latch();
     }
     if let Some(waterfall) = config.waterfall() {
         metrics.save_waterfall(waterfall);

--- a/rpc-perf/src/main.rs
+++ b/rpc-perf/src/main.rs
@@ -76,7 +76,6 @@ pub fn main() {
         let current = metrics.readings();
         let mut readings = readings.lock().unwrap();
         *readings = current;
-        metrics.latch();
     }
     if let Some(waterfall) = config.waterfall() {
         metrics.save_waterfall(waterfall);


### PR DESCRIPTION
Request timeout stat always shows as zero due to failure to
register with the metrics library.

Fix issue where blank waterfall is rendered.
