### PR TITLE
waterfall: fix rendering issues for some distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
  "timer 0.1.2",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "waterfall 0.4.0",
+ "waterfall 0.5.0",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "waterfall"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atomics 0.3.0",
  "datastructures 0.4.0",

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterfall"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/waterfall/examples/simulator.rs
+++ b/waterfall/examples/simulator.rs
@@ -21,7 +21,13 @@ fn main() {
 
     info!("Welcome to the simulator!");
 
-    for shape in &[Shape::Cauchy, Shape::Normal, Shape::Uniform] {
+    for shape in &[
+        Shape::Cauchy,
+        Shape::Normal,
+        Shape::Uniform,
+        Shape::Triangular,
+        Shape::Gamma,
+    ] {
         simulate(*shape);
     }
 }
@@ -31,17 +37,21 @@ pub enum Shape {
     Cauchy,
     Normal,
     Uniform,
+    Triangular,
+    Gamma,
 }
 
 pub fn simulate(shape: Shape) {
     println!("simulating for {:?}", shape);
-    let duration = 60;
+    let duration = 120;
 
     let heatmap = Heatmap::<AtomicU64>::new(SECOND, 3, SECOND, duration * SECOND);
 
-    let cauchy = Cauchy::new(200_000.0, 25_000.0).unwrap();
-    let normal = Normal::new(200_000.0, 25_000.0).unwrap();
-    let uniform = Uniform::new_inclusive(175_000.0, 225_000.0);
+    let cauchy = Cauchy::new(500_000.0, 2_000.00).unwrap();
+    let normal = Normal::new(200_000.0, 100_000.0).unwrap();
+    let uniform = Uniform::new_inclusive(10_000.0, 200_000.0);
+    let triangular = Triangular::new(1.0, 2_000_000.0, 50_000.0).unwrap();
+    let gamma = Gamma::new(2.0, 2.0).unwrap();
 
     let start = std::time::Instant::now();
     let mut latch = std::time::Instant::now();
@@ -61,6 +71,8 @@ pub fn simulate(shape: Shape) {
             Shape::Cauchy => cauchy.sample(&mut rng),
             Shape::Normal => normal.sample(&mut rng),
             Shape::Uniform => uniform.sample(&mut rng),
+            Shape::Triangular => triangular.sample(&mut rng),
+            Shape::Gamma => gamma.sample(&mut rng) * 1_000_000.0,
         };
         let value = value.floor() as u64;
         heatmap.increment(time::precise_time_ns(), value, 1);
@@ -97,6 +109,8 @@ pub fn render(shape: Shape, heatmap: Heatmap<AtomicU64>) {
         Shape::Cauchy => "cauchy.png",
         Shape::Normal => "normal.png",
         Shape::Uniform => "uniform.png",
+        Shape::Triangular => "tiangular.png",
+        Shape::Gamma => "gamma.png",
     };
 
     waterfall::save_waterfall(&heatmap, filename, labels, 60 * SECOND);


### PR DESCRIPTION
Previously, certain distributions could result in an all black
output. This was caused by rounding issues with integer arithmetic
in calculating the weighted count for the buckets.

Adjust the weighting algorithm to use a fixed multiplier and
increase precision used for storing the weighted counts.
Additionally, alter the coloring algorithm to improve rendering of
wide distributions. Adds additional distributions to the simulator
which were used to help identify issues.

The result is a more robust waterfall rendering which handles a
wider variety of distributions.
