### PR TITLE
enable sccache in ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ matrix:
   include:
     - os: linux
       rust: stable
-      env: TYPE=default RUST_BACKTRACE=1
+      env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
-        - cargo install sccache || true
         - cargo build --verbose
         - cargo test --verbose
         - cargo build --release --verbose
@@ -18,9 +17,8 @@ matrix:
         - cargo run --release -- --version
     - os: linux
       rust: stable
-      env: TYPE=tls RUST_BACKTRACE=1
+      env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
-        - cargo install sccache || true
         - cd rpc-perf
         - cargo build --features tls
         - cargo test --features tls
@@ -29,16 +27,14 @@ matrix:
         - cargo run --release --features tls -- --version
     - os: linux
       rust: stable
-      env: TYPE=rustfmt RUST_BACKTRACE=1
+      env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
-        - cargo install sccache || true
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
-      env: TYPE=clippy RUST_BACKTRACE=1
+      env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
-        - cargo install sccache || true
         - rustup toolchain install nightly-2020-05-01
         - rustup component add clippy --toolchain nightly-2020-05-01
         - cargo +nightly-2020-05-01 clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - os: linux
       rust: stable
-      env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=default RUST_BACKTRACE=1
       script:
         - cargo install sccache || true
         - cargo build --verbose
@@ -17,7 +17,7 @@ matrix:
         - cargo run --release -- --version
     - os: linux
       rust: stable
-      env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=tls RUST_BACKTRACE=1
       script:
         - cargo install sccache || true
         - cd rpc-perf
@@ -28,16 +28,18 @@ matrix:
         - cargo run --release --features tls -- --version
     - os: linux
       rust: stable
-      env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
         - cargo install sccache || true
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
-      env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=clippy RUST_BACKTRACE=1
       script:
         - cargo install sccache || true
         - rustup toolchain install nightly-2020-05-01
         - rustup component add clippy --toolchain nightly-2020-05-01
+        - cargo +nightly-2020-05-01 clippy
+        - cd rpc-perf
         - cargo +nightly-2020-05-01 clippy --features tls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - os: linux
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1
+      script:
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       rust: stable
       env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - cargo build --verbose
         - cargo test --verbose
         - cargo build --release --verbose
@@ -19,6 +20,7 @@ matrix:
       rust: stable
       env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - cd rpc-perf
         - cargo build --features tls
         - cargo test --features tls
@@ -29,12 +31,14 @@ matrix:
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - rustup toolchain install nightly-2020-05-01
         - rustup component add clippy --toolchain nightly-2020-05-01
         - cargo +nightly-2020-05-01 clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,37 @@ cache: cargo
 matrix:
   fast_finish: true
   include:
-    - os: linux
+    - name: "default"
+      os: linux
       rust: stable
       env: TYPE=default
       script:
         - bash build/ci.sh
-    - os: linux
+    - name: "tls"
+      os: linux
       rust: stable
       env: FEATURES=tls PACKAGE=rpc-perf
       script:
         - bash build/ci.sh
-    - os: linux
+    - name: "rustfmt"
+      os: linux
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
-        - rustup component add rustfmt --toolchain stable
-        - cargo +stable fmt -- --check
-    - os: linux
-      rust: nightly
+        - rustup component add rustfmt --toolchain ${TRAVIS_RUST_VERSION}
+        - cargo +${TRAVIS_RUST_VERSION} fmt -- --check
+    - name: "clippy"
+      os: linux
+      rust: nightly-2020-05-01
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - rustup toolchain install nightly-2020-05-01
-        - rustup component add clippy --toolchain nightly-2020-05-01
-        - cargo +nightly-2020-05-01 clippy
+        - rustup component add clippy --toolchain ${TRAVIS_RUST_VERSION}
+        - cargo +${TRAVIS_RUST_VERSION} clippy
         - cd rpc-perf
-        - cargo +nightly-2020-05-01 clippy --features tls
+        - cargo +${TRAVIS_RUST_VERSION} clippy --features tls
+    - name: "shellcheck"
+      os: linux
+      dist: bionic
+      rust: stable
+      script:
+        - shellcheck build/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       rust: stable
       env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - cargo build --verbose
         - cargo test --verbose
         - cargo build --release --verbose
@@ -18,6 +19,7 @@ matrix:
       rust: stable
       env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - cd rpc-perf
         - cargo build --features tls
         - cargo test --features tls
@@ -28,12 +30,14 @@ matrix:
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
+        - cargo install sccache || true
         - rustup toolchain install nightly-2020-05-01
         - rustup component add clippy --toolchain nightly-2020-05-01
         - cargo +nightly-2020-05-01 clippy --features tls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,37 +8,23 @@ matrix:
   include:
     - os: linux
       rust: stable
-      env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=default
       script:
-        - cargo install sccache || true
-        - cargo build --verbose
-        - cargo test --verbose
-        - cargo build --release --verbose
-        - cargo test --release --verbose
-        - cargo run --release -- --version
+        - bash build/ci.sh
     - os: linux
       rust: stable
-      env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: FEATURES=tls PACKAGE=rpc-perf
       script:
-        - cargo install sccache || true
-        - cd rpc-perf
-        - cargo build --features tls
-        - cargo test --features tls
-        - cargo build --release --features tls
-        - cargo test --release --features tls
-        - cargo run --release --features tls -- --version
+        - bash build/ci.sh
     - os: linux
       rust: stable
-      env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
-      script:
-        - cargo install sccache || true
+      env: TYPE=rustfmt RUST_BACKTRACE=1
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
-      env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
+      env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - cargo install sccache || true
         - rustup toolchain install nightly-2020-05-01
         - rustup component add clippy --toolchain nightly-2020-05-01
         - cargo +nightly-2020-05-01 clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - os: linux
       rust: stable
-      env: TYPE=default RUST_BACKTRACE=1
+      env: TYPE=default RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
         - cargo build --verbose
         - cargo test --verbose
@@ -16,7 +16,7 @@ matrix:
         - cargo run --release -- --version
     - os: linux
       rust: stable
-      env: TYPE=tls RUST_BACKTRACE=1
+      env: TYPE=tls RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
         - cd rpc-perf
         - cargo build --features tls
@@ -26,14 +26,14 @@ matrix:
         - cargo run --release --features tls -- --version
     - os: linux
       rust: stable
-      env: TYPE=rustfmt RUST_BACKTRACE=1
+      env: TYPE=rustfmt RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
       rust: nightly
-      env: TYPE=clippy RUST_BACKTRACE=1
+      env: TYPE=clippy RUST_BACKTRACE=1 RUSTC_WRAPPER=sccache
       script:
-        - rustup toolchain install nightly-2019-10-04
-        - rustup component add clippy --toolchain nightly-2019-10-04
-        - cargo +nightly-2019-10-04 clippy --features tls
+        - rustup toolchain install nightly-2020-05-01
+        - rustup component add clippy --toolchain nightly-2020-05-01
+        - cargo +nightly-2020-05-01 clippy --features tls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 os: linux
 dist: trusty
 sudo: required
+cache: cargo
 matrix:
   fast_finish: true
   include:

--- a/atomics/src/atomic_primitive/atomic_f32.rs
+++ b/atomics/src/atomic_primitive/atomic_f32.rs
@@ -16,7 +16,7 @@ impl AtomicPrimitive for AtomicF32 {
     type Primitive = f32;
 
     fn new(value: Self::Primitive) -> Self {
-        let value = unsafe { std::mem::transmute(value) };
+        let value = value.to_bits();
         Self {
             inner: core::sync::atomic::AtomicU32::new(value),
         }

--- a/atomics/src/atomic_primitive/atomic_f64.rs
+++ b/atomics/src/atomic_primitive/atomic_f64.rs
@@ -17,7 +17,7 @@ impl AtomicPrimitive for AtomicF64 {
     type Primitive = f64;
 
     fn new(value: Self::Primitive) -> Self {
-        let value = unsafe { std::mem::transmute(value) };
+        let value = value.to_bits();
         Self {
             inner: core::sync::atomic::AtomicU64::new(value),
         }

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -3,7 +3,7 @@
 set -e
 
 # try to install or use existing sccache
-if sccache --version > /dev/null; then
+if sccache --version > /dev/null 2>&1; then
 	echo "Using existing sccache"
 	export RUSTC_WRAPPER="sccache"
 	sccache --version

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -17,18 +17,18 @@ fi
 
 export RUST_BACKTRACE=1
 
-if [ -z ${FEATURES} ]; then
+if [ -z "${FEATURES}" ]; then
 	cargo build
 	cargo test
 	cargo build --release
 	cargo test --release
-elif [ -n ${PACKAGE} ]; then
+elif [ -n "${PACKAGE}" ]; then
 	# features can't be enabled in the virtual manifest, cd into package
-	cd ${PACKAGE}
-	cargo build --features ${FEATURES}
-	cargo test --features ${FEATURES}
-	cargo build --release --features ${FEATURES}
-	cargo test --release --features ${FEATURES}
+	cd "${PACKAGE}"
+	cargo build --features "${FEATURES}"
+	cargo test --features "${FEATURES}"
+	cargo build --release --features "${FEATURES}"
+	cargo test --release --features "${FEATURES}"
 else
 	echo "Specified FEATURES for build, but no PACKAGE"
 	exit 1

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+# try to install or use existing sccache
+if sccache --version > /dev/null; then
+	echo "Using existing sccache"
+	export RUSTC_WRAPPER="sccache"
+	sccache --version
+elif cargo install sccache; then
+	echo "Installed sccache"
+	export RUSTC_WRAPPER="sccache"
+	sccache --version
+else
+	echo "Building without sccache"
+fi
+
+export RUST_BACKTRACE=1
+
+if [ -z ${FEATURES} ]; then
+	cargo build
+	cargo test
+	cargo build --release
+	cargo test --release
+elif [ -n ${PACKAGE} ]; then
+	# features can't be enabled in the virtual manifest, cd into package
+	cd ${PACKAGE}
+	cargo build --features ${FEATURES}
+	cargo test --features ${FEATURES}
+	cargo build --release --features ${FEATURES}
+	cargo test --release --features ${FEATURES}
+else
+	echo "Specified FEATURES for build, but no PACKAGE"
+	exit 1
+fi

--- a/metrics-core/src/instant.rs
+++ b/metrics-core/src/instant.rs
@@ -4,8 +4,6 @@
 
 use std::ops::Sub;
 
-use time;
-
 /// High-resolution timestamp.
 ///
 /// This timestamp behaves in most respects like

--- a/metrics-core/src/scoped.rs
+++ b/metrics-core/src/scoped.rs
@@ -29,13 +29,19 @@ pub struct ScopedMetric<'m, M: MetricCommon> {
 
 impl<'m, M: Counter> ScopedMetric<'m, M> {
     /// Create a scoped counter from an existing counter reference.
+    ///
+    /// # Safety
+    /// For this type to be safe you must ensure that its drop implementation is
+    /// run. If this doesn't happen then values recorded to this metric will use a
+    /// dangling reference.
+    ///
     pub unsafe fn counter(
         name: impl Into<Cow<'static, str>>,
         metric: &'m M,
         metadata: impl Into<Option<Metadata>>,
     ) -> Result<Self, RegisterError> {
         let static_metric: &'static dyn Counter = mem::transmute(metric as &dyn Counter);
-        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let metadata = metadata.into().unwrap_or_else(Metadata::empty);
         let name = name.into();
 
         register_counter(name.clone(), static_metric, metadata)?;
@@ -49,13 +55,19 @@ impl<'m, M: Counter> ScopedMetric<'m, M> {
 
 impl<'m, M: Gauge> ScopedMetric<'m, M> {
     /// Create a scoped gauge from an existing gauge reference.
+    ///
+    /// # Safety
+    /// For this type to be safe you must ensure that its drop implementation is
+    /// run. If this doesn't happen then values recorded to this metric will use a
+    /// dangling reference.
+    ///
     pub unsafe fn gauge(
         name: impl Into<Cow<'static, str>>,
         metric: &'m M,
         metadata: impl Into<Option<Metadata>>,
     ) -> Result<Self, RegisterError> {
         let static_metric: &'static dyn Gauge = mem::transmute(metric as &dyn Gauge);
-        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let metadata = metadata.into().unwrap_or_else(Metadata::empty);
         let name = name.into();
 
         register_gauge(name.clone(), static_metric, metadata)?;
@@ -69,13 +81,19 @@ impl<'m, M: Gauge> ScopedMetric<'m, M> {
 
 impl<'m, M: Summary> ScopedMetric<'m, M> {
     /// Create a scoped summary from an existing summary reference.
+    ///
+    /// # Safety
+    /// For this type to be safe you must ensure that its drop implementation is
+    /// run. If this doesn't happen then values recorded to this metric will use a
+    /// dangling reference.
+    ///
     pub unsafe fn summary(
         name: impl Into<Cow<'static, str>>,
         metric: &'m M,
         metadata: impl Into<Option<Metadata>>,
     ) -> Result<Self, RegisterError> {
         let static_metric: &'static dyn Summary = mem::transmute(metric as &dyn Summary);
-        let metadata = metadata.into().unwrap_or(Metadata::empty());
+        let metadata = metadata.into().unwrap_or_else(Metadata::empty);
         let name = name.into();
 
         register_summary(name.clone(), static_metric, metadata)?;

--- a/metrics-core/src/state.rs
+++ b/metrics-core/src/state.rs
@@ -8,7 +8,6 @@ use std::sync::{
     Arc, Mutex,
 };
 
-use evmap;
 use once_cell::sync::Lazy;
 use thread_local::CachedThreadLocal;
 
@@ -111,7 +110,7 @@ impl State {
 
         writer.refresh();
 
-        return Ok(());
+        Ok(())
     }
 
     /// Unregister an existing metric, if the metric doesn't exist then this

--- a/rpc-perf/src/client/tls_client.rs
+++ b/rpc-perf/src/client/tls_client.rs
@@ -6,7 +6,6 @@ use crate::client::*;
 use crate::session::{Session, TLSSession};
 
 use mio::Token;
-use rustls;
 use rustls::ClientConfig;
 use slab::Slab;
 

--- a/rpc-perf/src/client/tls_client.rs
+++ b/rpc-perf/src/client/tls_client.rs
@@ -54,7 +54,7 @@ impl TLSClient {
         let mut tls_config = self
             .tls_config
             .take()
-            .unwrap_or_else(|| rustls::ClientConfig::new());
+            .unwrap_or_else(rustls::ClientConfig::new);
         tls_config
             .dangerous()
             .set_certificate_verifier(Arc::new(NoCertificateVerification {}));


### PR DESCRIPTION
Previously, we had no caching used in the ci build. This change enables travis cargo cache and tries to enable/build sccache to wrap rustc.
 