### PR TITLE
add cargo audit to ci

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -54,6 +54,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: clippy
       run: cargo clippy
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install
+      run: cargo install cargo-audit
+    - name: audit
+      run: cargo audit
   memcache-smoketest:
     name: memcache smoketest
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Adds cargo audit to ci to look for rustsec advisories for
dependencies. Currently warnings will not cause errors as there are
some existing warnings. Consider making this more strict in the
future.
