### PR TITLE
http metrics exposition fixes

### DIFF
--- a/rpc-perf/src/client/mod.rs
+++ b/rpc-perf/src/client/mod.rs
@@ -308,7 +308,7 @@ pub trait Client: Send {
                 State::Established => {
                     trace!("connection established {:?}", token);
                     if let Some(t0) = self.session(token).timestamp() {
-                        self.stat_interval(Stat::ConnectionsOpened, t0, Instant::now());
+                        self.stat_interval(Stat::ConnectionsLatency, t0, Instant::now());
                     }
                     self.do_established(token);
                 }
@@ -506,7 +506,7 @@ pub trait Client: Send {
 
                     if parsed != Err(Error::Incomplete) {
                         if let Some(t0) = self.session(token).timestamp() {
-                            self.stat_interval(Stat::ResponsesTotal, t0, t1);
+                            self.stat_interval(Stat::ResponsesLatency, t0, t1);
                             self.heatmap_increment(t0, t1);
                         }
                         trace!("switch to established");

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -246,7 +246,10 @@ impl Metrics {
         for stat in Stat::iter() {
             self.inner.register(&stat);
             match stat {
-                Stat::ConnectionsLatency | Stat::ResponsesLatency | Stat::KeySize | Stat::ValueSize => {
+                Stat::ConnectionsLatency
+                | Stat::ResponsesLatency
+                | Stat::KeySize
+                | Stat::ValueSize => {
                     // use heatmaps with 10 slices, each at 1/10th the interval
                     self.inner.add_summary(
                         &stat,

--- a/rpc-perf/src/stats/mod.rs
+++ b/rpc-perf/src/stats/mod.rs
@@ -115,8 +115,8 @@ impl StandardOut {
             "Hit-rate: {:.2}%",
             self.hitrate(&Stat::ResponsesHit, &Stat::ResponsesMiss, &current)
         );
-        self.display_percentiles(Stat::ConnectionsOpened, "Connect Latency", 1000, "us");
-        self.display_percentiles(Stat::ResponsesTotal, "Request Latency", 1000, "us");
+        self.display_percentiles(Stat::ConnectionsLatency, "Connect Latency", 1000, "us");
+        self.display_percentiles(Stat::ResponsesLatency, "Request Latency", 1000, "us");
         self.previous = current;
     }
 
@@ -246,7 +246,7 @@ impl Metrics {
         for stat in Stat::iter() {
             self.inner.register(&stat);
             match stat {
-                Stat::ResponsesTotal | Stat::KeySize | Stat::ValueSize => {
+                Stat::ConnectionsLatency | Stat::ResponsesLatency | Stat::KeySize | Stat::ValueSize => {
                     // use heatmaps with 10 slices, each at 1/10th the interval
                     self.inner.add_summary(
                         &stat,
@@ -260,6 +260,7 @@ impl Metrics {
                 }
                 _ => {}
             }
+            self.inner.add_output(&stat, Output::Reading);
             for percentile in &[50.0, 75.0, 90.0, 99.0, 99.9, 99.99] {
                 self.inner
                     .add_output(&stat, Output::Percentile(*percentile))

--- a/rpc-perf/src/stats/snapshot.rs
+++ b/rpc-perf/src/stats/snapshot.rs
@@ -44,7 +44,7 @@ impl MetricsSnapshot {
                     }
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("{}/histogram/p{:02} {}", label, percentile, value));
+                    data.push(format!("{}/p{:02} {}", label, percentile, value));
                 }
             }
         }
@@ -69,7 +69,7 @@ impl MetricsSnapshot {
                     }
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("{}/histogram/p{:02}: {}", label, percentile, value));
+                    data.push(format!("{}/p{:02}: {}", label, percentile, value));
                 }
             }
         }
@@ -97,7 +97,7 @@ impl MetricsSnapshot {
                     }
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("{}/histogram/p{:02}: {}", label, percentile, value));
+                    data.push(format!("{}/p{:02}: {}", label, percentile, value));
                 }
             }
         }

--- a/rpc-perf/src/stats/stat.rs
+++ b/rpc-perf/src/stats/stat.rs
@@ -31,6 +31,10 @@ pub enum Stat {
     ConnectionsServerClosed,
     #[strum(serialize = "connections/timeout")]
     ConnectionsTimeout,
+    #[strum(serialize = "connections/latency")]
+    ConnectionsLatency,
+    #[strum(serialize = "responses/latency")]
+    ResponsesLatency,
     #[strum(serialize = "responses/total")]
     ResponsesTotal,
     #[strum(serialize = "responses/ok")]
@@ -76,7 +80,7 @@ impl Statistic<AtomicU64, AtomicU32> for Stat {
 
     fn source(&self) -> Source {
         match self {
-            Self::KeySize | Self::ValueSize | Self::ConnectionsOpened | Self::ResponsesTotal => {
+            Self::KeySize | Self::ValueSize | Self::ConnectionsLatency | Self::ResponsesLatency => {
                 Source::Distribution
             }
             _ => Source::Counter,


### PR DESCRIPTION
Fixes for http metrics exposition where counter metrics were not
being displayed.

Changes latency metrics to be responses/latency/* and
connections/latency/*
