### PR TITLE
update rustcommon-buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,15 +769,15 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rustcommon-buffer"
-version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+version = "0.2.0"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "bytes",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-datastructures"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "log",
  "rustcommon-atomics",
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "log",
  "time",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "crossbeam",
  "dashmap",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-ratelimiter"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "rand",
  "rand_distr",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-timer"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "log",
 ]
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-waterfall"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon?branch=master#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "chrono",
  "dejavu",

--- a/src/codec/echo.rs
+++ b/src/codec/echo.rs
@@ -77,8 +77,8 @@ impl Codec for Echo {
 
 #[cfg(test)]
 mod tests {
+    use bytes::*;
     use super::*;
-    use bytes::BufMut;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/echo.rs
+++ b/src/codec/echo.rs
@@ -77,8 +77,8 @@ impl Codec for Echo {
 
 #[cfg(test)]
 mod tests {
-    use bytes::*;
     use super::*;
+    use bytes::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -218,6 +218,7 @@ impl Codec for Memcache {
 
 #[cfg(test)]
 mod tests {
+    use bytes::*;
     use super::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -7,7 +7,7 @@ use crate::config::Action;
 use crate::stats::Stat;
 use std::io::{BufRead, BufReader};
 
-use bytes::{Buf, BytesMut};
+use bytes::Buf;
 
 pub struct Memcache {
     common: Common,
@@ -20,15 +20,15 @@ impl Memcache {
         }
     }
 
-    pub fn get(&self, buf: &mut BytesMut, key: &[u8]) {
-        buf.extend_from_slice(b"get ");
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b"\r\n");
+    pub fn get(&self, buf: &mut Buffer, key: &[u8]) {
+        buf.put_slice(b"get ");
+        buf.put_slice(key);
+        buf.put_slice(b"\r\n");
     }
 
     pub fn set(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         key: &[u8],
         value: &[u8],
         exptime: Option<u32>,
@@ -38,17 +38,17 @@ impl Memcache {
         let flags = format!("{}", flags.unwrap_or(0));
         let length = format!("{}", value.len());
 
-        buf.extend_from_slice(b"set ");
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b" ");
-        buf.extend_from_slice(flags.as_bytes());
-        buf.extend_from_slice(b" ");
-        buf.extend_from_slice(exptime.as_bytes());
-        buf.extend_from_slice(b" ");
-        buf.extend_from_slice(length.as_bytes());
-        buf.extend_from_slice(b"\r\n");
-        buf.extend_from_slice(value);
-        buf.extend_from_slice(b"\r\n");
+        buf.put_slice(b"set ");
+        buf.put_slice(key);
+        buf.put_slice(b" ");
+        buf.put_slice(flags.as_bytes());
+        buf.put_slice(b" ");
+        buf.put_slice(exptime.as_bytes());
+        buf.put_slice(b" ");
+        buf.put_slice(length.as_bytes());
+        buf.put_slice(b"\r\n");
+        buf.put_slice(value);
+        buf.put_slice(b"\r\n");
     }
 }
 
@@ -188,7 +188,7 @@ impl Codec for Memcache {
         Err(Error::Unknown)
     }
 
-    fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng) {
+    fn encode(&mut self, buf: &mut Buffer, rng: &mut ThreadRng) {
         let command = self.generate(rng);
         match command.action() {
             Action::Get => {
@@ -308,17 +308,27 @@ mod tests {
 
     #[test]
     fn encode_get() {
-        let mut buf = BytesMut::new();
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+
+        test_case.put_slice(b"get 0\r\n");
+
         let encoder = Memcache::new();
         encoder.get(&mut buf, b"0");
-        assert_eq!(&buf[..], b"get 0\r\n");
+
+        assert_eq!(buf, test_case);
     }
 
     #[test]
     fn encode_set() {
-        let mut buf = BytesMut::new();
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+
+        test_case.put_slice(b"set 0 0 0 5\r\nvalue\r\n");
+
         let encoder = Memcache::new();
         encoder.set(&mut buf, b"0", b"value", None, None);
-        assert_eq!(&buf[..], b"set 0 0 0 5\r\nvalue\r\n");
+
+        assert_eq!(buf, test_case);
     }
 }

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -218,8 +218,8 @@ impl Codec for Memcache {
 
 #[cfg(test)]
 mod tests {
-    use bytes::*;
     use super::*;
+    use bytes::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -15,13 +15,13 @@ pub use memcache::Memcache;
 pub use pelikan_rds::PelikanRds;
 pub use ping::Ping;
 pub use redis::{Redis, RedisMode};
+use rustcommon_buffer::Buffer;
 pub use thrift_cache::ThriftCache;
 
 use crate::config::{Action, Config, Generator};
 use crate::stats::Metrics;
 use std::sync::Arc;
 
-use bytes::BytesMut;
 use rand::rngs::ThreadRng;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -300,7 +300,7 @@ pub trait Codec: Send {
     fn common(&self) -> &Common;
     fn common_mut(&mut self) -> &mut Common;
     fn decode(&self, buf: &[u8]) -> Result<Response, Error>;
-    fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng);
+    fn encode(&mut self, buf: &mut Buffer, rng: &mut ThreadRng);
 
     fn generate(&self, rng: &mut ThreadRng) -> Command {
         self.common().generator.generate(rng)

--- a/src/codec/pelikan_rds.rs
+++ b/src/codec/pelikan_rds.rs
@@ -354,6 +354,7 @@ impl Codec for PelikanRds {
 
 #[cfg(test)]
 mod tests {
+    use bytes::*;
     use super::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {

--- a/src/codec/pelikan_rds.rs
+++ b/src/codec/pelikan_rds.rs
@@ -354,8 +354,8 @@ impl Codec for PelikanRds {
 
 #[cfg(test)]
 mod tests {
-    use bytes::*;
     use super::*;
+    use bytes::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/pelikan_rds.rs
+++ b/src/codec/pelikan_rds.rs
@@ -10,7 +10,7 @@ use crate::codec::*;
 use crate::config::Action;
 use crate::stats::Stat;
 
-use bytes::{Buf, BytesMut};
+use bytes::Buf;
 
 pub struct PelikanRds {
     common: Common,
@@ -23,36 +23,36 @@ impl PelikanRds {
         }
     }
 
-    pub fn get(&self, buf: &mut BytesMut, key: &[u8]) {
-        buf.extend_from_slice(format!("*2\r\n$3\r\nget\r\n${}\r\n", key.len()).as_bytes());
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b"\r\n");
+    pub fn get(&self, buf: &mut Buffer, key: &[u8]) {
+        buf.put_slice(format!("*2\r\n$3\r\nget\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn set(&self, buf: &mut BytesMut, key: &[u8], value: &[u8], ttl: Option<usize>) {
+    pub fn set(&self, buf: &mut Buffer, key: &[u8], value: &[u8], ttl: Option<usize>) {
         if ttl.is_some() {
-            buf.extend_from_slice(b"*5\r\n");
+            buf.put_slice(b"*5\r\n");
         } else {
-            buf.extend_from_slice(b"*3\r\n");
+            buf.put_slice(b"*3\r\n");
         }
-        buf.extend_from_slice(format!("$3\r\nset\r\n${}\r\n", key.len()).as_bytes());
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
-        buf.extend_from_slice(value);
-        buf.extend_from_slice(b"\r\n");
+        buf.put_slice(format!("$3\r\nset\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
+        buf.put_slice(value);
+        buf.put_slice(b"\r\n");
         if let Some(ttl_value) = ttl {
             let formated_ttl = format!("{}", ttl_value);
-            buf.extend_from_slice(b"$2\r\nEX\r\n");
-            buf.extend_from_slice(format!("${}\r\n", formated_ttl.len()).as_bytes());
-            buf.extend_from_slice(formated_ttl.as_bytes());
-            buf.extend_from_slice(b"\r\n");
+            buf.put_slice(b"$2\r\nEX\r\n");
+            buf.put_slice(format!("${}\r\n", formated_ttl.len()).as_bytes());
+            buf.put_slice(formated_ttl.as_bytes());
+            buf.put_slice(b"\r\n");
         }
     }
 
     #[allow(clippy::unnecessary_unwrap)]
     pub fn sarray_create(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         key: &[u8],
         esize: usize,
         watermark_low: Option<usize>,
@@ -60,57 +60,43 @@ impl PelikanRds {
     ) {
         let esize = format!("{}", esize);
         if watermark_low.is_some() && watermark_high.is_some() {
-            buf.extend_from_slice(
-                format!("*5\r\n$13\r\nSArray.create\r\n${}\r\n", key.len()).as_bytes(),
-            );
+            buf.put_slice(format!("*5\r\n$13\r\nSArray.create\r\n${}\r\n", key.len()).as_bytes());
         } else {
-            buf.extend_from_slice(
-                format!("*3\r\n$13\r\nSArray.create\r\n${}\r\n", key.len()).as_bytes(),
-            );
+            buf.put_slice(format!("*3\r\n$13\r\nSArray.create\r\n${}\r\n", key.len()).as_bytes());
         }
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(format!("\r\n${}\r\n{}\r\n", esize.len(), esize).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(format!("\r\n${}\r\n{}\r\n", esize.len(), esize).as_bytes());
         if watermark_low.is_some() && watermark_high.is_some() {
             let watermark_low = format!("{}", watermark_low.unwrap());
             let watermark_high = format!("{}", watermark_high.unwrap());
-            buf.extend_from_slice(
-                format!("${}\r\n{}\r\n", watermark_low.len(), watermark_low).as_bytes(),
-            );
-            buf.extend_from_slice(
+            buf.put_slice(format!("${}\r\n{}\r\n", watermark_low.len(), watermark_low).as_bytes());
+            buf.put_slice(
                 format!("${}\r\n{}\r\n", watermark_high.len(), watermark_high).as_bytes(),
             );
         }
     }
 
-    pub fn sarray_delete(&self, buf: &mut BytesMut, key: &[u8]) {
-        buf.extend_from_slice(
-            format!("*2\r\n$13\r\nSArray.delete\r\n${}\r\n", key.len()).as_bytes(),
-        );
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b"\r\n");
+    pub fn sarray_delete(&self, buf: &mut Buffer, key: &[u8]) {
+        buf.put_slice(format!("*2\r\n$13\r\nSArray.delete\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_len(&self, buf: &mut BytesMut, key: &[u8]) {
-        buf.extend_from_slice(format!("*2\r\n$10\r\nSArray.len\r\n${}\r\n", key.len()).as_bytes());
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b"\r\n");
+    pub fn sarray_len(&self, buf: &mut Buffer, key: &[u8]) {
+        buf.put_slice(format!("*2\r\n$10\r\nSArray.len\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_find(&self, buf: &mut BytesMut, key: &[u8], value: &[u8]) {
-        buf.extend_from_slice(format!("*3\r\n$11\r\nSArray.find\r\n${}\r\n", key.len()).as_bytes());
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
-        buf.extend_from_slice(value);
-        buf.extend_from_slice(b"\r\n");
+    pub fn sarray_find(&self, buf: &mut Buffer, key: &[u8], value: &[u8]) {
+        buf.put_slice(format!("*3\r\n$11\r\nSArray.find\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
+        buf.put_slice(value);
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_get(
-        &self,
-        buf: &mut BytesMut,
-        key: &[u8],
-        index: Option<u64>,
-        count: Option<u64>,
-    ) {
+    pub fn sarray_get(&self, buf: &mut Buffer, key: &[u8], index: Option<u64>, count: Option<u64>) {
         let index = if count.is_some() && index.is_none() {
             Some("0".to_string())
         } else {
@@ -118,57 +104,55 @@ impl PelikanRds {
         };
         let count = count.map(|v| format!("{}", v));
         if index.is_some() && count.is_some() {
-            buf.extend_from_slice(b"*4\r\n");
+            buf.put_slice(b"*4\r\n");
         } else if index.is_some() {
-            buf.extend_from_slice(b"*3\r\n");
+            buf.put_slice(b"*3\r\n");
         } else {
-            buf.extend_from_slice(b"*2\r\n");
+            buf.put_slice(b"*2\r\n");
         }
-        buf.extend_from_slice(format!("$10\r\nSArray.get\r\n${}\r\n", key.len()).as_bytes());
-        buf.extend_from_slice(key);
+        buf.put_slice(format!("$10\r\nSArray.get\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
         if let Some(index) = index {
-            buf.extend_from_slice(format!("\r\n${}\r\n{}", index.len(), index).as_bytes());
+            buf.put_slice(format!("\r\n${}\r\n{}", index.len(), index).as_bytes());
         }
         if let Some(count) = count {
-            buf.extend_from_slice(format!("\r\n${}\r\n{}", count.len(), count).as_bytes());
+            buf.put_slice(format!("\r\n${}\r\n{}", count.len(), count).as_bytes());
         }
-        buf.extend_from_slice(b"\r\n");
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_insert(&self, buf: &mut BytesMut, key: &[u8], values: &[&[u8]]) {
+    pub fn sarray_insert(&self, buf: &mut Buffer, key: &[u8], values: &[&[u8]]) {
         let args = 2 + values.len();
-        buf.extend_from_slice(
+        buf.put_slice(
             format!("*{}\r\n$13\r\nSArray.insert\r\n${}\r\n", args, key.len()).as_bytes(),
         );
-        buf.extend_from_slice(key);
+        buf.put_slice(key);
         for value in values {
-            buf.extend_from_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
-            buf.extend_from_slice(value);
+            buf.put_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
+            buf.put_slice(value);
         }
-        buf.extend_from_slice(b"\r\n");
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_remove(&self, buf: &mut BytesMut, key: &[u8], values: &[&[u8]]) {
+    pub fn sarray_remove(&self, buf: &mut Buffer, key: &[u8], values: &[&[u8]]) {
         let args = 2 + values.len();
-        buf.extend_from_slice(
+        buf.put_slice(
             format!("*{}\r\n$13\r\nSArray.remove\r\n${}\r\n", args, key.len()).as_bytes(),
         );
-        buf.extend_from_slice(key);
+        buf.put_slice(key);
         for value in values {
-            buf.extend_from_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
-            buf.extend_from_slice(value);
+            buf.put_slice(format!("\r\n${}\r\n", value.len()).as_bytes());
+            buf.put_slice(value);
         }
-        buf.extend_from_slice(b"\r\n");
+        buf.put_slice(b"\r\n");
     }
 
-    pub fn sarray_truncate(&self, buf: &mut BytesMut, key: &[u8], count: u64) {
+    pub fn sarray_truncate(&self, buf: &mut Buffer, key: &[u8], count: u64) {
         let count = format!("{}", count);
-        buf.extend_from_slice(
-            format!("*3\r\n$15\r\nSArray.truncate\r\n${}\r\n", key.len()).as_bytes(),
-        );
-        buf.extend_from_slice(key);
-        buf.extend_from_slice(b"\r\n");
-        buf.extend_from_slice(format!("${}\r\n{}\r\n", count.len(), count).as_bytes());
+        buf.put_slice(format!("*3\r\n$15\r\nSArray.truncate\r\n${}\r\n", key.len()).as_bytes());
+        buf.put_slice(key);
+        buf.put_slice(b"\r\n");
+        buf.put_slice(format!("${}\r\n{}\r\n", count.len(), count).as_bytes());
     }
 }
 
@@ -260,7 +244,7 @@ impl Codec for PelikanRds {
         }
     }
 
-    fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng) {
+    fn encode(&mut self, buf: &mut Buffer, rng: &mut ThreadRng) {
         let command = self.generate(rng);
         match command.action() {
             Action::Get => {
@@ -423,11 +407,10 @@ mod tests {
     #[test]
     fn encode_ttl() {
         let c = PelikanRds::new();
-        let mut buf = BytesMut::with_capacity(64);
-        let mut test_case = BytesMut::with_capacity(64);
-        test_case.extend_from_slice(
-            b"*5\r\n$3\r\nset\r\n$3\r\nabc\r\n$4\r\n1234\r\n$2\r\nEX\r\n$4\r\n9876\r\n",
-        );
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case
+            .put_slice(b"*5\r\n$3\r\nset\r\n$3\r\nabc\r\n$4\r\n1234\r\n$2\r\nEX\r\n$4\r\n9876\r\n");
         c.set(&mut buf, b"abc", b"1234", Some(9876));
 
         assert_eq!(test_case, buf);
@@ -436,9 +419,9 @@ mod tests {
     #[test]
     fn encode_without_ttl() {
         let c = PelikanRds::new();
-        let mut buf = BytesMut::with_capacity(64);
-        let mut test_case = BytesMut::with_capacity(64);
-        test_case.extend_from_slice(b"*3\r\n$3\r\nset\r\n$3\r\nabc\r\n$4\r\n1234\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$3\r\nset\r\n$3\r\nabc\r\n$4\r\n1234\r\n");
         c.set(&mut buf, b"abc", b"1234", None);
 
         assert_eq!(test_case, buf);
@@ -447,15 +430,15 @@ mod tests {
     #[test]
     fn encode_sarray_create() {
         let c = PelikanRds::new();
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*3\r\n$13\r\nSArray.create\r\n$3\r\nabc\r\n$2\r\n64\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$13\r\nSArray.create\r\n$3\r\nabc\r\n$2\r\n64\r\n");
         c.sarray_create(&mut buf, b"abc", 64, None, None);
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(
             b"*5\r\n$13\r\nSArray.create\r\n$3\r\nabc\r\n$2\r\n64\r\n$4\r\n3000\r\n$4\r\n3200\r\n",
         );
         c.sarray_create(&mut buf, b"abc", 64, Some(3000), Some(3200));
@@ -465,9 +448,9 @@ mod tests {
     #[test]
     fn encode_sarray_delete() {
         let c = PelikanRds::new();
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*2\r\n$13\r\nSArray.delete\r\n$3\r\nabc\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*2\r\n$13\r\nSArray.delete\r\n$3\r\nabc\r\n");
         c.sarray_delete(&mut buf, b"abc");
         assert_eq!(test_case, buf);
     }
@@ -476,29 +459,27 @@ mod tests {
     fn encode_sarray_get() {
         let c = PelikanRds::new();
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*2\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*2\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n");
         c.sarray_get(&mut buf, b"abc", None, None);
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*3\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$2\r\n42\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$2\r\n42\r\n");
         c.sarray_get(&mut buf, b"abc", Some(42), None);
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case
-            .extend_from_slice(b"*4\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$2\r\n42\r\n$1\r\n8\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*4\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$2\r\n42\r\n$1\r\n8\r\n");
         c.sarray_get(&mut buf, b"abc", Some(42), Some(8));
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case
-            .extend_from_slice(b"*4\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$1\r\n0\r\n$1\r\n8\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*4\r\n$10\r\nSArray.get\r\n$3\r\nabc\r\n$1\r\n0\r\n$1\r\n8\r\n");
         c.sarray_get(&mut buf, b"abc", None, Some(8));
         assert_eq!(test_case, buf);
     }
@@ -507,18 +488,17 @@ mod tests {
     fn encode_sarray_insert() {
         let c = PelikanRds::new();
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*3\r\n$13\r\nSArray.insert\r\n$3\r\nabc\r\n$2\r\n42\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$13\r\nSArray.insert\r\n$3\r\nabc\r\n$2\r\n42\r\n");
         let values: Vec<&[u8]> = vec![b"42"];
         c.sarray_insert(&mut buf, b"abc", &values);
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(
-            b"*4\r\n$13\r\nSArray.insert\r\n$3\r\nabc\r\n$2\r\n42\r\n$3\r\n206\r\n",
-        );
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case
+            .put_slice(b"*4\r\n$13\r\nSArray.insert\r\n$3\r\nabc\r\n$2\r\n42\r\n$3\r\n206\r\n");
         let values: Vec<&[u8]> = vec![b"42", b"206"];
         c.sarray_insert(&mut buf, b"abc", &values);
         assert_eq!(test_case, buf);
@@ -528,18 +508,17 @@ mod tests {
     fn encode_sarray_remove() {
         let c = PelikanRds::new();
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*3\r\n$13\r\nSArray.remove\r\n$3\r\nabc\r\n$2\r\n42\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$13\r\nSArray.remove\r\n$3\r\nabc\r\n$2\r\n42\r\n");
         let values: Vec<&[u8]> = vec![b"42"];
         c.sarray_remove(&mut buf, b"abc", &values);
         assert_eq!(test_case, buf);
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(
-            b"*4\r\n$13\r\nSArray.remove\r\n$3\r\nabc\r\n$2\r\n42\r\n$3\r\n206\r\n",
-        );
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case
+            .put_slice(b"*4\r\n$13\r\nSArray.remove\r\n$3\r\nabc\r\n$2\r\n42\r\n$3\r\n206\r\n");
         let values: Vec<&[u8]> = vec![b"42", b"206"];
         c.sarray_remove(&mut buf, b"abc", &values);
         assert_eq!(test_case, buf);
@@ -549,9 +528,9 @@ mod tests {
     fn encode_sarray_truncate() {
         let c = PelikanRds::new();
 
-        let mut buf = BytesMut::with_capacity(128);
-        let mut test_case = BytesMut::with_capacity(128);
-        test_case.extend_from_slice(b"*3\r\n$15\r\nSArray.truncate\r\n$3\r\nabc\r\n$2\r\n42\r\n");
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"*3\r\n$15\r\nSArray.truncate\r\n$3\r\nabc\r\n$2\r\n42\r\n");
         c.sarray_truncate(&mut buf, b"abc", 42);
         assert_eq!(test_case, buf);
     }

--- a/src/codec/ping.rs
+++ b/src/codec/ping.rs
@@ -51,6 +51,7 @@ impl Codec for Ping {
 
 #[cfg(test)]
 mod tests {
+    use bytes::*;
     use super::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {

--- a/src/codec/ping.rs
+++ b/src/codec/ping.rs
@@ -16,8 +16,8 @@ impl Ping {
         }
     }
 
-    pub fn ping(&self, buf: &mut BytesMut) {
-        buf.extend_from_slice(b"PING\r\n");
+    pub fn ping(&self, buf: &mut Buffer) {
+        buf.put_slice(b"PING\r\n");
     }
 }
 
@@ -44,7 +44,7 @@ impl Codec for Ping {
         }
     }
 
-    fn encode(&mut self, buf: &mut BytesMut, _rng: &mut ThreadRng) {
+    fn encode(&mut self, buf: &mut Buffer, _rng: &mut ThreadRng) {
         self.ping(buf);
     }
 }
@@ -89,9 +89,11 @@ mod tests {
 
     #[test]
     fn encode_ping() {
-        let mut buf = BytesMut::new();
+        let mut buf = Buffer::new();
+        let mut test_case = Buffer::new();
+        test_case.put_slice(b"PING\r\n");
         let encoder = Ping::new();
         encoder.ping(&mut buf);
-        assert_eq!(&buf[..], b"PING\r\n");
+        assert_eq!(buf, test_case);
     }
 }

--- a/src/codec/ping.rs
+++ b/src/codec/ping.rs
@@ -51,8 +51,8 @@ impl Codec for Ping {
 
 #[cfg(test)]
 mod tests {
-    use bytes::*;
     use super::*;
+    use bytes::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/redis.rs
+++ b/src/codec/redis.rs
@@ -351,6 +351,7 @@ impl Codec for Redis {
 
 #[cfg(test)]
 mod tests {
+    use bytes::*;
     use super::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {

--- a/src/codec/redis.rs
+++ b/src/codec/redis.rs
@@ -351,8 +351,8 @@ impl Codec for Redis {
 
 #[cfg(test)]
 mod tests {
-    use bytes::*;
     use super::*;
+    use bytes::*;
 
     fn decode_messages(messages: Vec<&'static [u8]>, response: Result<Response, Error>) {
         for message in messages {

--- a/src/codec/thrift.rs
+++ b/src/codec/thrift.rs
@@ -21,22 +21,22 @@ pub const SET: u8 = 14;
 pub const LIST: u8 = 15;
 
 #[derive(Clone)]
-pub struct Buffer {
+pub struct ThriftBuffer {
     buffer: Vec<u8>,
 }
 
-impl Default for Buffer {
-    fn default() -> Buffer {
+impl Default for ThriftBuffer {
+    fn default() -> Self {
         let mut buffer = Vec::<u8>::new();
         buffer.resize(4, 0);
 
-        Buffer { buffer }
+        Self { buffer }
     }
 }
 
-impl Buffer {
-    pub fn new() -> Buffer {
-        Buffer::default()
+impl ThriftBuffer {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn len(&self) -> usize {
@@ -150,7 +150,7 @@ mod test {
 
     #[test]
     fn ping() {
-        let mut buffer = Buffer::new();
+        let mut buffer = ThriftBuffer::new();
 
         // new buffer has 4 bytes to hold framing later
         assert_eq!(buffer.len(), 4);

--- a/src/codec/thrift_cache.rs
+++ b/src/codec/thrift_cache.rs
@@ -5,8 +5,7 @@
 use crate::codec::*;
 use crate::config::Action;
 use crate::stats::Stat;
-
-use bytes::BytesMut;
+use rustcommon_buffer::Buffer;
 
 pub struct ThriftCache {
     common: Common,
@@ -21,13 +20,13 @@ impl ThriftCache {
 
     pub fn append(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
         values: &[&[u8]],
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("append");
         buffer.sequence_id(sequence_id);
@@ -66,18 +65,18 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     pub fn appendx(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
         values: &[&[u8]],
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("appendx");
         buffer.sequence_id(sequence_id);
@@ -116,18 +115,18 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     pub fn count(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("appendx");
         buffer.sequence_id(sequence_id);
@@ -162,19 +161,19 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     pub fn get(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
         fields: &[&[u8]],
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("get");
         buffer.sequence_id(sequence_id);
@@ -216,13 +215,13 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn put(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
@@ -232,7 +231,7 @@ impl ThriftCache {
         ttl: Option<i64>,
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("put");
         buffer.sequence_id(sequence_id);
@@ -299,19 +298,19 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     pub fn range(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
         start: Option<i32>,
         stop: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("range");
         buffer.sequence_id(sequence_id);
@@ -349,13 +348,13 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn remove(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
@@ -364,7 +363,7 @@ impl ThriftCache {
         count: Option<i32>,
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("remove");
         buffer.sequence_id(sequence_id);
@@ -417,13 +416,13 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn scan(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
@@ -433,7 +432,7 @@ impl ThriftCache {
         limit: Option<i32>,
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("appendx");
         buffer.sequence_id(sequence_id);
@@ -492,13 +491,13 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn trim(
         &self,
-        buf: &mut BytesMut,
+        buf: &mut Buffer,
         sequence_id: i32,
         table: &[u8],
         key: &[u8],
@@ -506,7 +505,7 @@ impl ThriftCache {
         trim_from_smallest: bool,
         timeout: Option<i32>,
     ) {
-        let mut buffer = thrift::Buffer::new();
+        let mut buffer = thrift::ThriftBuffer::new();
         buffer.protocol_header();
         buffer.method_name("trim");
         buffer.sequence_id(sequence_id);
@@ -545,7 +544,7 @@ impl ThriftCache {
         buffer.stop();
         buffer.frame();
 
-        buf.extend_from_slice(buffer.as_bytes());
+        buf.put_slice(buffer.as_bytes());
     }
 }
 
@@ -585,7 +584,7 @@ impl Codec for ThriftCache {
     }
 
     // TODO(bmartin): fix stats
-    fn encode(&mut self, buf: &mut BytesMut, rng: &mut ThreadRng) {
+    fn encode(&mut self, buf: &mut Buffer, rng: &mut ThreadRng) {
         let command = self.generate(rng);
         match command.action() {
             Action::Hget => {
@@ -677,12 +676,12 @@ mod test {
 
     #[test]
     fn get() {
-        let mut buf = BytesMut::new();
+        let mut buf = Buffer::new();
         let codec = ThriftCache::new();
         codec.get(&mut buf, 0, b"0", b"key", &[b"alpha"], None);
-        let mut check = BytesMut::new();
+        let mut check = Buffer::new();
 
-        check.extend_from_slice(&[
+        check.put_slice(&[
             0, 0, 0, 60, // len
             128, 1, 0, 1, // protocol
             0, 0, 0, 3, // method length


### PR DESCRIPTION
Update rustcommon to pull-in new buffer library. Makes necessary
code changes to use the new buffer library.
