### PR TITLE
Remove Sample Output link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ well as testing new hardware platforms and network changes.
 * [Getting rpc-perf](#getting-rpc-perf)
 * [Configuration](#configuration)
 * [Sample Usage](#sample-usage)
-* [Sample Output](#sample-output)
 * [Practices](#practices)
 * [Features](#features)
 * [Future Work](#future-work)


### PR DESCRIPTION
Sample output removed from README.md because there isn't a section for sample output

Problem

There isn't a section for sample output so the link should be removed

Solution

Remove Sample output link from README.md
