### PR TITLE
add TLS session cache support

### DIFF
--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -35,6 +35,8 @@ pub struct General {
     tls_key: Option<String>,
     tls_cert: Option<String>,
     tls_ca: Option<String>,
+    #[serde(default = "default_tls_session_cache_size")]
+    tls_session_cache_size: usize,
     warmup_hitrate: Option<f64>,
     #[serde(default = "default_tcp_nodelay")]
     tcp_nodelay: bool,
@@ -204,6 +206,14 @@ impl General {
         self.tls_ca = file;
     }
 
+    pub fn tls_session_cache_size(&self) -> usize {
+        self.tls_session_cache_size
+    }
+
+    pub fn set_tls_session_cache_size(&mut self, size: usize) {
+        self.tls_session_cache_size = size;
+    }
+
     pub fn set_warmup_hitrate(&mut self, hitrate: Option<f64>) {
         self.warmup_hitrate = hitrate;
     }
@@ -240,6 +250,7 @@ impl Default for General {
             tls_key: None,
             tls_cert: None,
             tls_ca: None,
+            tls_session_cache_size: 0,
             warmup_hitrate: None,
             tcp_nodelay: default_tcp_nodelay(),
             request_timeout: default_request_timeout(),
@@ -280,6 +291,10 @@ fn default_connect_timeout() -> usize {
 
 fn default_soft_timeout() -> bool {
     false
+}
+
+fn default_tls_session_cache_size() -> usize {
+    0
 }
 
 #[derive(Copy, Clone, Deserialize, Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -744,8 +744,11 @@ impl Config {
             config.general.set_waterfall(Some(waterfall.to_string()));
         }
 
-        if let Some(tls_session_cache_size) = parse_numeric_arg(&matches, "tls-session-cache-size") {
-            config.general.set_tls_session_cache_size(tls_session_cache_size);
+        if let Some(tls_session_cache_size) = parse_numeric_arg(&matches, "tls-session-cache-size")
+        {
+            config
+                .general
+                .set_tls_session_cache_size(tls_session_cache_size);
         }
 
         config
@@ -858,7 +861,6 @@ impl Config {
     pub fn waterfall(&self) -> Option<String> {
         self.general.waterfall()
     }
-
 
     fn load_from_file(filename: &str) -> Config {
         let mut file = std::fs::File::open(filename).expect("failed to open workload file");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -591,6 +591,13 @@ impl Config {
                     .value_name("File")
                     .help("Certificate Authority for TLS authentication")
                     .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("tls-session-cache-size")
+                    .long("tls-session-cache-size")
+                    .value_name("Number")
+                    .help("the maximum number of TLS stored sessions")
+                    .takes_value(true),
             );
 
         let matches = app.get_matches();
@@ -737,6 +744,10 @@ impl Config {
             config.general.set_waterfall(Some(waterfall.to_string()));
         }
 
+        if let Some(tls_session_cache_size) = parse_numeric_arg(&matches, "tls-session-cache-size") {
+            config.general.set_tls_session_cache_size(tls_session_cache_size);
+        }
+
         config
     }
 
@@ -836,6 +847,10 @@ impl Config {
         self.general.tls_ca()
     }
 
+    pub fn tls_session_cache_size(&self) -> usize {
+        self.general.tls_session_cache_size()
+    }
+
     pub fn warmup_hitrate(&self) -> Option<f64> {
         self.general.warmup_hitrate()
     }
@@ -843,6 +858,7 @@ impl Config {
     pub fn waterfall(&self) -> Option<String> {
         self.general.waterfall()
     }
+
 
     fn load_from_file(filename: &str) -> Config {
         let mut file = std::fs::File::open(filename).expect("failed to open workload file");


### PR DESCRIPTION
Problem

To test TLS session impact on a server side rpc-perf should be able to reconnect with and w/o TLS session cache
The current implementation does not use that feature of rusttls

Solution

Add option to control TLS number of cached sessions. 

Result

We can test TLS session impact