### PR TITLE
fix: prometheus metric naming and typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 vendor
 .cargo
 **/*.rs.bk
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target
 vendor
 .cargo
 **/*.rs.bk
-.idea

--- a/src/stats/snapshot.rs
+++ b/src/stats/snapshot.rs
@@ -39,15 +39,21 @@ impl MetricsSnapshot {
                 Output::Reading => {
                     if let Some(ref count_label) = self.count_label {
                         let metric_name = format!("{}/{}", label, count_label);
-                        data.push(format!("# TYPE {} gauge\n{} {}", metric_name, metric_name, value));
+                        data.push(format!(
+                            "# TYPE {} gauge\n{} {}",
+                            metric_name, metric_name, value
+                        ));
                     } else {
                         data.push(format!("# TYPE {} gauge\n{} {}", label, label, value));
                     }
                 }
                 Output::Percentile(percentile) => {
                     // per prometheus naming https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels metric names cannot have . in them
-                    let metric_name = format!("{}/p{:02}", label, percentile).replace(".","");
-                    data.push(format!("# TYPE {} gauge\n{} {}", metric_name, metric_name, value));
+                    let metric_name = format!("{}/p{:02}", label, percentile).replace(".", "");
+                    data.push(format!(
+                        "# TYPE {} gauge\n{} {}",
+                        metric_name, metric_name, value
+                    ));
                 }
             }
         }

--- a/src/stats/snapshot.rs
+++ b/src/stats/snapshot.rs
@@ -38,19 +38,23 @@ impl MetricsSnapshot {
             match output {
                 Output::Reading => {
                     if let Some(ref count_label) = self.count_label {
-                        data.push(format!("{}/{} {}", label, count_label, value));
+                        let metric_name = format!("{}/{}", label, count_label);
+                        data.push(format!("# TYPE {} gauge\n{} {}", metric_name, metric_name, value));
                     } else {
-                        data.push(format!("{} {}", label, value));
+                        data.push(format!("# TYPE {} gauge\n{} {}", label, label, value));
                     }
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("{}/p{:02} {}", label, percentile, value));
+                    // per prometheus naming https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels metric names cannot have . in them
+                    let metric_name = format!("{}/p{:02}", label, percentile).replace(".","");
+                    data.push(format!("# TYPE {} gauge\n{} {}", metric_name, metric_name, value));
                 }
             }
         }
         data.sort();
         let mut content = data.join("\n");
         content += "\n";
+
         let parts: Vec<&str> = content.split('/').collect();
         parts.join("_")
     }

--- a/src/stats/snapshot.rs
+++ b/src/stats/snapshot.rs
@@ -49,10 +49,12 @@ impl MetricsSnapshot {
                 }
                 Output::Percentile(percentile) => {
                     // per prometheus naming https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels metric names cannot have . in them
-                    let metric_name = format!("{}/p{:02}", label, percentile).replace(".", "");
+                    let metric_label = format!("{}", label);
+                    let metric_name =
+                        format!("{}{{percentile=\"{:02}\"}}", metric_label, percentile);
                     data.push(format!(
                         "# TYPE {} gauge\n{} {}",
-                        metric_name, metric_name, value
+                        metric_label, metric_name, value
                     ));
                 }
             }

--- a/src/stats/snapshot.rs
+++ b/src/stats/snapshot.rs
@@ -48,7 +48,6 @@ impl MetricsSnapshot {
                     }
                 }
                 Output::Percentile(percentile) => {
-                    // per prometheus naming https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels metric names cannot have . in them
                     let metric_label = format!("{}", label);
                     let metric_name =
                         format!("{}{{percentile=\"{:02}\"}}", metric_label, percentile);


### PR DESCRIPTION
**Problem**
There are 2 issues:
- Some prometheus metrics collectors (ex. [open telemetry](https://github.com/open-telemetry/opentelemetry-collector/issues/3118)) don't support untyped prometheus metrics. Per the [prometheus spec](https://prometheus.io/docs/instrumenting/exposition_formats/#line-format), an optional metric `TYPE` can be added to each metric. Open telemetry requires this to process metrics
- [Prometheus](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels) requires metric names to match this regex `[a-zA-Z_:][a-zA-Z0-9_:]*`, so metrics such as `responses_latency_p99.99` are actually invalid due to the `.` Using open telemetry, it won't process any of the metrics if one of the metrics is of invalid format.

**Solution**

I have changed the metric format to be
```
# TYPE {metric_name} gauge
{metric_name} {metric_value}
```
and removed the `.` from all metric names. So `responses_latency_p99.99` becomes `responses_latency_p9999`.

**Result**

The open telemetry collector can process and understand the prometheus metrics emitted from `rpc-perf`
