### PR TITLE
TLSCache: turn off if cache size is 0

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,6 +15,7 @@ use rand::thread_rng;
 use rustcommon_timer::Wheel;
 use rustls::ClientConfig;
 use rustls::ClientSessionMemoryCache;
+use rustls::NoClientSessionStorage;
 use slab::Slab;
 
 use crate::codec::*;
@@ -452,9 +453,11 @@ fn load_tls_config(config: &Arc<Config>) -> Option<Arc<rustls::ClientConfig>> {
             .set_single_client_cert(cert, key)
             .expect("invalid cert or key");
 
-        if session_cache_size > 0 {
-            config.session_persistence = ClientSessionMemoryCache::new(session_cache_size);
-        }
+        
+        config.session_persistence = match session_cache_size {
+            0 => Arc::new(NoClientSessionStorage{}),
+            _ => ClientSessionMemoryCache::new(session_cache_size)
+        };
 
         Some(Arc::new(config))
     } else if cert_chain.is_none() && cert.is_none() && key.is_none() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -453,10 +453,9 @@ fn load_tls_config(config: &Arc<Config>) -> Option<Arc<rustls::ClientConfig>> {
             .set_single_client_cert(cert, key)
             .expect("invalid cert or key");
 
-        
         config.session_persistence = match session_cache_size {
-            0 => Arc::new(NoClientSessionStorage{}),
-            _ => ClientSessionMemoryCache::new(session_cache_size)
+            0 => Arc::new(NoClientSessionStorage {}),
+            _ => ClientSessionMemoryCache::new(session_cache_size),
         };
 
         Some(Arc::new(config))

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -250,7 +250,7 @@ impl Default for General {
             tls_key: None,
             tls_cert: None,
             tls_ca: None,
-            tls_session_cache_size: 0,
+            tls_session_cache_size: 32, // to match default cache size value in rustls library
             warmup_hitrate: None,
             tcp_nodelay: default_tcp_nodelay(),
             request_timeout: default_request_timeout(),


### PR DESCRIPTION
Problem

TLSConfig has default session size [32](https://docs.rs/rustls/0.18.1/src/rustls/client/mod.rs.html#164).
Current code implementation left default cache on even if provided option says 0.
But the expectation is when the cache size option is 0 the expectation is to avoid caching at all.

Solution

Turn off cache when the cache size is 0

Result

session cache size 0 turns off caching completely
