### PR TITLE
Convert metrics to use `rustcommon-metrics-v2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,6 @@ dependencies = [
  "rand_distr 0.4.0",
  "rand_xoshiro",
  "rtrb",
- "rustcommon-fastmetrics",
  "rustcommon-heatmap",
  "rustcommon-logger",
  "rustcommon-metrics-v2",
@@ -825,14 +824,6 @@ version = "1.0.0"
 source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "rustcommon-fastmetrics"
-version = "0.0.3"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "serde",
 ]
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-fastmetrics"
 version = "0.0.3"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "thiserror",
 ]
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "log",
  "time",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "linkme",
  "parking_lot",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-ratelimiter"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d827387d3171e2d5925f29835b77dc0ae57d614c"
 dependencies = [
  "rand 0.7.3",
  "rand_distr 0.2.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,15 +417,44 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "linkme"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f7a548defb4c688d16c333586fe92907d774c2df78037ab098b8f7202bf7fb"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcc41894750103e29b7d4b0763bbf807eb723ce78626c461cf6dadb84124ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -555,6 +593,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,19 +630,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.24"
+name = "proc-macro-crate"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -694,6 +767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rpc-perf"
 version = "4.0.0-alpha.0"
 dependencies = [
@@ -712,6 +794,7 @@ dependencies = [
  "rustcommon-fastmetrics",
  "rustcommon-heatmap",
  "rustcommon-logger",
+ "rustcommon-metrics-v2",
  "rustcommon-ratelimiter",
  "serde",
  "serde_derive",
@@ -739,7 +822,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "serde",
 ]
@@ -747,7 +830,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-fastmetrics"
 version = "0.0.3"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "thiserror",
 ]
@@ -755,7 +838,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -766,7 +849,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -775,16 +858,37 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "log",
  "time",
 ]
 
 [[package]]
+name = "rustcommon-metrics-derive"
+version = "0.1.0"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rustcommon-metrics-v2"
+version = "0.1.0"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
+dependencies = [
+ "linkme",
+ "parking_lot",
+ "rustcommon-metrics-derive",
+]
+
+[[package]]
 name = "rustcommon-ratelimiter"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#66003c551e69bc7727cd653de14ffaf2d17ab2b3"
+source = "git+https://github.com/twitter/rustcommon?branch=master#d7ecec8e97e63f77ebfa843ed493ecbd0d883c2d"
 dependencies = [
  "rand 0.7.3",
  "rand_distr 0.2.2",
@@ -839,6 +943,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
 name = "snowflake"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -913,18 +1023,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rand = { version = "0.8.0", features = ["small_rng"] }
 rand_xoshiro = { version = "0.6.0" }
 rand_distr = "0.4.0"
 rtrb = "*"
-rustcommon-fastmetrics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-heatmap = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-ratelimiter = { git = "https://github.com/twitter/rustcommon", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustcommon-fastmetrics = { git = "https://github.com/twitter/rustcommon", branch
 rustcommon-heatmap = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-ratelimiter = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", branch = "master", package = "rustcommon-metrics-v2" }
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_json = "*"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -80,8 +80,6 @@ impl Admin {
             Snapshot::new(self.connect_heatmap.as_ref(), self.request_heatmap.as_ref());
         loop {
             while Instant::now() < next {
-                snapshot =
-                    Snapshot::new(self.connect_heatmap.as_ref(), self.request_heatmap.as_ref());
                 if let Some(ref server) = self.server {
                     while let Ok(Some(mut request)) = server.try_recv() {
                         let url = request.url();
@@ -148,6 +146,8 @@ impl Admin {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
+
+            snapshot = Snapshot::new(self.connect_heatmap.as_ref(), self.request_heatmap.as_ref());
             next += match self.config.as_ref() {
                 Some(config) => config.general().interval(),
                 None => Duration::from_secs(60),
@@ -258,8 +258,10 @@ impl Snapshot {
             };
 
             if let Some(counter) = any.downcast_ref::<Counter>() {
+                info!("METRIC: {} = {}", metric.name(), counter.value());
                 counters.insert(metric.name(), counter.value());
             } else if let Some(gauge) = any.downcast_ref::<Gauge>() {
+                info!("METRIC: {} = {}", metric.name(), gauge.value());
                 gauges.insert(metric.name(), gauge.value());
             }
         }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -7,7 +7,6 @@ use crate::Arc;
 use crate::Config;
 use rustcommon_heatmap::AtomicHeatmap;
 use rustcommon_heatmap::AtomicU64;
-use rustcommon_metrics::{Counter, Gauge};
 use rustcommon_ratelimiter::Ratelimiter;
 use std::collections::HashMap;
 use std::time::Instant;

--- a/src/codec/echo.rs
+++ b/src/codec/echo.rs
@@ -58,7 +58,6 @@ impl Codec for Echo {
                 let crc_bytes: [u8; 4] = unsafe { std::mem::transmute(crc_calc.to_be()) };
                 if crc_bytes != crc[..] {
                     debug!("Response has bad CRC: {:?} != {:?}", crc, crc_bytes);
-                    increment_counter!(&Metric::ResponseEx);
                     metrics::RESPONSE_EX.increment();
                     Err(ParseError::Error)
                 } else {

--- a/src/codec/echo.rs
+++ b/src/codec/echo.rs
@@ -59,6 +59,7 @@ impl Codec for Echo {
                 if crc_bytes != crc[..] {
                     debug!("Response has bad CRC: {:?} != {:?}", crc, crc_bytes);
                     increment_counter!(&Metric::ResponseEx);
+                    metrics::RESPONSE_EX.increment();
                     Err(ParseError::Error)
                 } else {
                     let _ = buffer.split_to(response_end + 2);

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -61,6 +61,7 @@ impl Codec for Memcache {
         match command.verb() {
             Verb::Get => {
                 increment_counter!(&Metric::RequestGet);
+                metrics::REQUEST_GET.increment();
                 Memcache::get(&mut self.rng, keyspace, buf)
             }
             Verb::Set => Memcache::set(&mut self.rng, keyspace, buf),
@@ -98,6 +99,7 @@ impl Codec for Memcache {
             while let Some(line_end) = lines.position(|w| w == b"\r\n") {
                 if response_buf.len() >= 5 && &response_buf[start..(start + 5)] == b"VALUE" {
                     increment_counter!(&Metric::ResponseHit);
+                    metrics::RESPONSE_HIT.increment();
                 }
                 start = line_end + 2;
             }

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -60,7 +60,6 @@ impl Codec for Memcache {
         let command = keyspace.choose_command(&mut self.rng);
         match command.verb() {
             Verb::Get => {
-                increment_counter!(&Metric::RequestGet);
                 metrics::REQUEST_GET.increment();
                 Memcache::get(&mut self.rng, keyspace, buf)
             }
@@ -98,7 +97,6 @@ impl Codec for Memcache {
             let mut lines = response_buf.windows(2);
             while let Some(line_end) = lines.position(|w| w == b"\r\n") {
                 if response_buf.len() >= 5 && &response_buf[start..(start + 5)] == b"VALUE" {
-                    increment_counter!(&Metric::ResponseHit);
                     metrics::RESPONSE_HIT.increment();
                 }
                 start = line_end + 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,10 @@ mod metrics;
 mod session;
 mod worker;
 
-use crate::admin::Admin;
-use crate::config::Config;
-use crate::metrics::*;
-use crate::session::Session;
+pub use crate::admin::Admin;
+pub use crate::config::Config;
+pub use crate::metrics::*;
+pub use crate::session::Session;
 use core::time::Duration;
 use rustcommon_heatmap::AtomicHeatmap;
 use rustcommon_heatmap::AtomicU64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,6 @@
 extern crate rustcommon_logger;
 
 #[macro_use]
-extern crate rustcommon_fastmetrics;
-
-#[macro_use]
 mod macros;
 
 mod admin;
@@ -41,8 +38,6 @@ pub struct Builder {
 impl Builder {
     /// Create a new runtime builder from the given config
     pub fn new(config: Option<String>) -> Self {
-        metrics_init();
-
         let config = Config::new(config);
 
         let config = Arc::new(config);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_fastmetrics::{MetricsBuilder, Source};
-use strum::IntoEnumIterator;
 use rustcommon_metrics::{metric, Counter, Gauge};
 
 /// Number of connect attempts.
@@ -81,63 +79,3 @@ pub static SESSION_SEND_EX: Counter = Counter::new();
 /// Number of bytes sent.
 #[metric(name = "session_send_byte")]
 pub static SESSION_SEND_BYTE: Counter = Counter::new();
-
-use strum_macros::{AsRefStr, EnumIter};
-
-#[deprecated]
-#[derive(Debug, Clone, Copy, AsRefStr, EnumIter, Hash, Eq, PartialEq)]
-#[strum(serialize_all = "snake_case")]
-pub enum Metric {
-    Connect,         // connect attempts
-    ConnectEx,       // connect errors
-    ConnectTimeout,  // connect timeouts
-    Request,         // requests sent
-    RequestEx,       // request errors
-    RequestGet,      // 'get' keys for hitrate calc
-    Response,        // 'ok' responses for success rate calc
-    ResponseEx,      // 'error' responses for success rate
-    ResponseHit,     // 'hit' responses for hitrate calc
-    Close,           // closed connections
-    Window,          // elapsed windows
-    Session,         // number of sessions
-    Open,            // number of open connections
-    SessionRecv,     // times recv has been called
-    SessionRecvEx,   // number of errors calling recv
-    SessionRecvByte, // number of bytes received
-    SessionSend,     // times send has been called
-    SessionSendEx,   // number of errors calling send
-    SessionSendByte, // number of bytes sent
-}
-
-impl Into<usize> for Metric {
-    fn into(self) -> usize {
-        self as usize
-    }
-}
-
-impl std::fmt::Display for Metric {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.as_ref())
-    }
-}
-
-impl rustcommon_fastmetrics::Metric for Metric {
-    fn index(&self) -> usize {
-        (*self).into()
-    }
-
-    fn source(&self) -> Source {
-        match self {
-            Metric::Open => Source::Gauge,
-            _ => Source::Counter,
-        }
-    }
-}
-
-pub fn metrics_init() {
-    let metrics: Vec<Metric> = Metric::iter().collect();
-    MetricsBuilder::<Metric>::new()
-        .metrics(&metrics)
-        .build()
-        .unwrap();
-}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::{metric, Counter, Gauge};
+use rustcommon_metrics::metric;
+
+pub use rustcommon_metrics::{Counter, Gauge};
 
 /// Number of connect attempts.
 #[metric(name = "connect")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -84,6 +84,7 @@ pub static SESSION_SEND_BYTE: Counter = Counter::new();
 
 use strum_macros::{AsRefStr, EnumIter};
 
+#[deprecated]
 #[derive(Debug, Clone, Copy, AsRefStr, EnumIter, Hash, Eq, PartialEq)]
 #[strum(serialize_all = "snake_case")]
 pub enum Metric {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,6 +4,83 @@
 
 use rustcommon_fastmetrics::{MetricsBuilder, Source};
 use strum::IntoEnumIterator;
+use rustcommon_metrics::{metric, Counter, Gauge};
+
+/// Number of connect attempts.
+#[metric(name = "connect")]
+pub static CONNECT: Counter = Counter::new();
+
+/// Number of connect errors.
+#[metric(name = "connect_ex")]
+pub static CONNECT_EX: Counter = Counter::new();
+
+/// Number of connect timeouts.
+#[metric(name = "connect_timeout")]
+pub static CONNECT_TIMEOUT: Counter = Counter::new();
+
+/// Number of requests sent.
+#[metric(name = "request")]
+pub static REQUEST: Counter = Counter::new();
+
+/// Number of request errors.
+#[metric(name = "request_ex")]
+pub static REQUEST_EX: Counter = Counter::new();
+
+/// 'get' requests for hitrate calculations.
+#[metric(name = "request_get")]
+pub static REQUEST_GET: Counter = Counter::new();
+
+/// 'ok' responses for success rate calculations
+#[metric(name = "response")]
+pub static RESPONSE: Counter = Counter::new();
+
+/// 'error' responses for success rate calculations
+#[metric(name = "response_ex")]
+pub static RESPONSE_EX: Counter = Counter::new();
+
+/// 'hit' responses for hitrate calculations
+#[metric(name = "response_hit")]
+pub static RESPONSE_HIT: Counter = Counter::new();
+
+/// Number of closed connections.
+#[metric(name = "close")]
+pub static CLOSE: Counter = Counter::new();
+
+/// Number of elapsed windows.
+#[metric(name = "window")]
+pub static WINDOW: Counter = Counter::new();
+
+/// Number of sessions.
+#[metric(name = "session")]
+pub static SESSION: Counter = Counter::new();
+
+/// Number of currently open connections.
+#[metric(name = "open")]
+pub static OPEN: Gauge = Gauge::new();
+
+/// Number of times recv has been called.
+#[metric(name = "session_recv")]
+pub static SESSION_RECV: Counter = Counter::new();
+
+/// Number of errors calling recv.
+#[metric(name = "session_recv_ex")]
+pub static SESSION_RECV_EX: Counter = Counter::new();
+
+/// Number of bytes received.
+#[metric(name = "session_recv_byte")]
+pub static SESSION_RECV_BYTE: Counter = Counter::new();
+
+/// Number of times send has been called.
+#[metric(name = "session_send")]
+pub static SESSION_SEND: Counter = Counter::new();
+
+/// Number of errors calling send.
+#[metric(name = "session_send_ex")]
+pub static SESSION_SEND_EX: Counter = Counter::new();
+
+/// Number of bytes sent.
+#[metric(name = "session_send_byte")]
+pub static SESSION_SEND_BYTE: Counter = Counter::new();
 
 use strum_macros::{AsRefStr, EnumIter};
 

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -29,15 +29,17 @@ use std::io::{BufRead, BufReader, ErrorKind};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::{Duration, Instant};
 
-mod metrics;
-mod session;
+use rpc_perf::*;
 
-use crate::metrics::*;
-use crate::session::Session;
+/// TODO(bmartin): this should be consolidated with rpc-perf
+use rustcommon_heatmap::AtomicHeatmap;
+use rustcommon_heatmap::AtomicU64;
+use std::sync::Arc;
 
 // TODO(bmartin): this should be split up into a library and binary
 fn main() {
     // initialize metrics
+    rpc_perf::
     metrics_init();
 
     // initialize logging
@@ -185,7 +187,7 @@ fn main() {
     )));
 
     // spawn admin
-    let mut admin = Admin::new(None);
+    let mut admin = Admin::for_replay(None);
     admin.set_request_heatmap(request_heatmap.clone());
     let _admin_thread = std::thread::spawn(move || admin.run());
 
@@ -369,9 +371,11 @@ impl Worker {
     pub fn send_request(&mut self, token: Token, request: Request) {
         let session = self.sessions.get_mut(token.0).expect("bad token");
         increment_counter!(&Metric::Request);
+        REQUEST.increment();
         match request {
             Request::Get { key } => {
                 increment_counter!(&Metric::RequestGet);
+                REQUEST_GET.increment();
                 session
                     .write_buffer
                     .extend_from_slice(format!("get {}\r\n", key).as_bytes());
@@ -379,6 +383,7 @@ impl Worker {
             }
             Request::Gets { key } => {
                 increment_counter!(&Metric::RequestGet);
+                REQUEST_GET.increment();
                 session
                     .write_buffer
                     .extend_from_slice(format!("gets {}\r\n", key).as_bytes());
@@ -488,6 +493,7 @@ impl Worker {
                         Ok(Some(_)) => match decode(&mut session.read_buffer) {
                             Ok(_) => {
                                 increment_counter!(&Metric::Response);
+                                RESPONSE.increment();
                                 if let Some(ref heatmap) = self.request_heatmap {
                                     let now = Instant::now();
                                     let elapsed = now - session.timestamp();
@@ -570,336 +576,12 @@ fn decode(buffer: &mut BytesMut) -> Result<(), ParseError> {
     let mut windows = buf.windows(5);
     if let Some(response_end) = windows.position(|w| w == b"END\r\n") {
         if response_end > 0 {
-            increment_counter!(&Metric::ResponseHit)
+            increment_counter!(&Metric::ResponseHit);
+            RESPONSE_HIT.increment();
         }
         let _ = buffer.split_to(response_end + 5);
         return Ok(());
     }
 
     Err(ParseError::Incomplete)
-}
-
-/// TODO(bmartin): this should be consolidated with rpc-perf
-use crate::metrics::Metric;
-use rustcommon_fastmetrics::{Metric as MetricTrait, Source};
-use rustcommon_heatmap::AtomicHeatmap;
-use rustcommon_heatmap::AtomicU64;
-use rustcommon_ratelimiter::Ratelimiter;
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use strum::IntoEnumIterator;
-use tiny_http::{Method, Response, Server};
-
-pub struct Admin {
-    snapshot: Snapshot,
-    connect_heatmap: Option<Arc<AtomicHeatmap<u64, AtomicU64>>>,
-    request_heatmap: Option<Arc<AtomicHeatmap<u64, AtomicU64>>>,
-    request_ratelimit: Option<Arc<Ratelimiter>>,
-    server: Option<Server>,
-}
-
-impl Admin {
-    pub fn new(admin_addr: Option<SocketAddr>) -> Self {
-        let snapshot = Snapshot::new(None, None);
-        let server = admin_addr.map(|admin_addr| Server::http(admin_addr).unwrap());
-
-        Self {
-            snapshot,
-            connect_heatmap: None,
-            request_heatmap: None,
-            request_ratelimit: None,
-            server,
-        }
-    }
-
-    pub fn set_connect_heatmap(&mut self, heatmap: Option<Arc<AtomicHeatmap<u64, AtomicU64>>>) {
-        self.connect_heatmap = heatmap;
-    }
-
-    pub fn set_request_heatmap(&mut self, heatmap: Option<Arc<AtomicHeatmap<u64, AtomicU64>>>) {
-        self.request_heatmap = heatmap;
-    }
-
-    pub fn set_request_ratelimit(&mut self, ratelimiter: Option<Arc<Ratelimiter>>) {
-        self.request_ratelimit = ratelimiter;
-    }
-
-    pub fn run(mut self) {
-        // let mut next = Instant::now() + self.config.general().interval();
-        let mut next = Instant::now() + Duration::from_secs(60);
-        let mut snapshot =
-            Snapshot::new(self.connect_heatmap.as_ref(), self.request_heatmap.as_ref());
-        loop {
-            while Instant::now() < next {
-                snapshot =
-                    Snapshot::new(self.connect_heatmap.as_ref(), self.request_heatmap.as_ref());
-                if let Some(ref server) = self.server {
-                    while let Ok(Some(mut request)) = server.try_recv() {
-                        let url = request.url();
-                        let parts: Vec<&str> = url.split('?').collect();
-                        let url = parts[0];
-                        match request.method() {
-                            Method::Get => match url {
-                                "/" => {
-                                    debug!("Serving GET on index");
-                                    let _ = request.respond(Response::from_string(format!(
-                                        "Welcome to {}\nVersion: {}\n",
-                                        "rpc-replay", "0.0.0",
-                                    )));
-                                }
-                                "/metrics" => {
-                                    debug!("Serving Prometheus compatible stats");
-                                    let _ = request
-                                        .respond(Response::from_string(self.snapshot.prometheus()));
-                                }
-                                "/metrics.json" | "/vars.json" | "/admin/metrics.json" => {
-                                    debug!("Serving machine readable stats");
-                                    let _ = request
-                                        .respond(Response::from_string(self.snapshot.json()));
-                                }
-                                "/vars" => {
-                                    debug!("Serving human readable stats");
-                                    let _ = request
-                                        .respond(Response::from_string(self.snapshot.human()));
-                                }
-                                url => {
-                                    debug!("GET on non-existent url: {}", url);
-                                    debug!("Serving machine readable stats");
-                                    let _ = request
-                                        .respond(Response::from_string(self.snapshot.json()));
-                                }
-                            },
-                            Method::Put => match request.url() {
-                                "/ratelimit/request" => {
-                                    let mut content = String::new();
-                                    request.as_reader().read_to_string(&mut content).unwrap();
-                                    if let Ok(rate) = content.parse() {
-                                        if let Some(ref ratelimiter) = self.request_ratelimit {
-                                            ratelimiter.set_rate(rate);
-                                            let _ = request.respond(Response::empty(200));
-                                        } else {
-                                            let _ = request.respond(Response::empty(400));
-                                        }
-                                    } else {
-                                        let _ = request.respond(Response::empty(400));
-                                    }
-                                }
-                                url => {
-                                    debug!("PUT on non-existent url: {}", url);
-                                    let _ = request.respond(Response::empty(404));
-                                }
-                            },
-                            method => {
-                                debug!("unsupported request method: {}", method);
-                                let _ = request.respond(Response::empty(404));
-                            }
-                        }
-                    }
-                }
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
-            next += Duration::from_secs(60);
-
-            let window = get_counter!(&Metric::Window).unwrap_or(0);
-
-            info!("-----");
-            info!("Window: {}", window);
-
-            let request_rate = snapshot.rate(&self.snapshot, Metric::Request);
-            let response_rate = snapshot.rate(&self.snapshot, Metric::Response);
-            let connect_rate = snapshot.rate(&self.snapshot, Metric::Connect);
-
-            info!(
-                "Rate: Request: {:.2} rps Response: {:.2} rps Connect: {:.2} cps",
-                request_rate, response_rate, connect_rate
-            );
-
-            let request_success =
-                snapshot.success_rate(&self.snapshot, Metric::Request, Metric::RequestEx);
-            let response_success =
-                snapshot.success_rate(&self.snapshot, Metric::Response, Metric::ResponseEx);
-            let connect_success =
-                snapshot.success_rate(&self.snapshot, Metric::Connect, Metric::ConnectEx);
-
-            info!(
-                "Success: Request: {:.2} % Response: {:.2} % Connect: {:.2} %",
-                request_success, response_success, connect_success
-            );
-
-            let hit_rate =
-                snapshot.hitrate(&self.snapshot, Metric::RequestGet, Metric::ResponseHit);
-
-            info!("Hit-rate: {:.2} %", hit_rate);
-
-            if let Some(ref heatmap) = self.request_heatmap {
-                let p25 = heatmap.percentile(0.25).unwrap_or(0);
-                let p50 = heatmap.percentile(0.50).unwrap_or(0);
-                let p75 = heatmap.percentile(0.75).unwrap_or(0);
-                let p90 = heatmap.percentile(0.90).unwrap_or(0);
-                let p99 = heatmap.percentile(0.99).unwrap_or(0);
-                let p999 = heatmap.percentile(0.999).unwrap_or(0);
-                let p9999 = heatmap.percentile(0.9999).unwrap_or(0);
-                info!("Response Latency (us): p25: {} p50: {} p75: {} p90: {} p99: {} p999: {} p9999: {}",
-                    p25, p50, p75, p90, p99, p999, p9999
-                );
-            }
-
-            increment_counter!(&Metric::Window);
-            self.snapshot = snapshot.clone();
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct Snapshot {
-    counters: HashMap<Metric, u64>,
-    _gauges: HashMap<Metric, i64>,
-    timestamp: Instant,
-    connect_percentiles: Vec<(String, u64)>,
-    request_percentiles: Vec<(String, u64)>,
-}
-
-impl Snapshot {
-    fn new(
-        connect_heatmap: Option<&Arc<AtomicHeatmap<u64, AtomicU64>>>,
-        request_heatmap: Option<&Arc<AtomicHeatmap<u64, AtomicU64>>>,
-    ) -> Self {
-        let mut counters = HashMap::new();
-        let mut gauges = HashMap::new();
-        for metric in Metric::iter() {
-            match metric.source() {
-                Source::Counter => {
-                    let value = get_counter!(&metric).unwrap_or(0);
-                    counters.insert(metric, value);
-                }
-                Source::Gauge => {
-                    let value = get_gauge!(&metric).unwrap_or(0);
-                    gauges.insert(metric, value);
-                }
-            }
-        }
-
-        let percentiles = vec![
-            ("p25", 0.25),
-            ("p50", 0.50),
-            ("p75", 0.75),
-            ("p90", 0.90),
-            ("p99", 0.99),
-            ("p999", 0.999),
-            ("p9999", 0.9999),
-        ];
-
-        let mut connect_percentiles = Vec::new();
-        if let Some(ref heatmap) = connect_heatmap {
-            for (label, value) in &percentiles {
-                connect_percentiles
-                    .push((label.to_string(), heatmap.percentile(*value).unwrap_or(0)));
-            }
-        }
-
-        let mut request_percentiles = Vec::new();
-        if let Some(ref heatmap) = request_heatmap {
-            for (label, value) in &percentiles {
-                request_percentiles
-                    .push((label.to_string(), heatmap.percentile(*value).unwrap_or(0)));
-            }
-        }
-
-        Self {
-            counters,
-            _gauges: gauges,
-            timestamp: Instant::now(),
-            connect_percentiles,
-            request_percentiles,
-        }
-    }
-
-    fn delta_count(&self, other: &Self, counter: Metric) -> u64 {
-        let this = self.counters.get(&counter).unwrap_or(&0);
-        let other = other.counters.get(&counter).unwrap_or(&0);
-        this - other
-    }
-
-    fn rate(&self, other: &Self, counter: Metric) -> f64 {
-        let delta = self.delta_count(other, counter) as f64;
-        let time = (self.timestamp - other.timestamp).as_secs_f64();
-        delta / time
-    }
-
-    fn success_rate(&self, other: &Self, total: Metric, error: Metric) -> f64 {
-        let total = self.rate(other, total);
-        let error = self.rate(other, error);
-        if total > 0.0 {
-            100.0 - (100.0 * error / total)
-        } else {
-            100.0
-        }
-    }
-
-    fn hitrate(&self, other: &Self, total: Metric, hit: Metric) -> f64 {
-        let total = self.rate(other, total);
-        let hit = self.rate(other, hit);
-        if total > 0.0 {
-            100.0 * hit / total
-        } else {
-            0.0
-        }
-    }
-
-    pub fn human(&self) -> String {
-        let mut data = Vec::new();
-        for (counter, value) in &self.counters {
-            data.push(format!("{}: {}", counter, value));
-        }
-        for (label, value) in &self.connect_percentiles {
-            data.push(format!("connect/latency/{}: {}", label, value));
-        }
-        for (label, value) in &self.request_percentiles {
-            data.push(format!("response/latency/{}: {}", label, value));
-        }
-        data.sort();
-        let mut content = data.join("\n");
-        content += "\n";
-        content
-    }
-
-    pub fn json(&self) -> String {
-        let head = "{".to_owned();
-
-        let mut data = Vec::new();
-        for (label, value) in &self.counters {
-            data.push(format!("\"{}\": {}", label, value));
-        }
-        for (label, value) in &self.connect_percentiles {
-            data.push(format!("\"connect/latency/{}\": {}", label, value));
-        }
-        for (label, value) in &self.request_percentiles {
-            data.push(format!("\"response/latency/{}\": {}", label, value));
-        }
-        data.sort();
-        let body = data.join(",");
-        let mut content = head;
-        content += &body;
-        content += "}";
-        content
-    }
-
-    pub fn prometheus(&self) -> String {
-        let mut data = Vec::new();
-        for (counter, value) in &self.counters {
-            data.push(format!("{} {}", counter, value));
-        }
-        for (label, value) in &self.connect_percentiles {
-            data.push(format!("connect/latency/{}: {}", label, value));
-        }
-        for (label, value) in &self.request_percentiles {
-            data.push(format!("response/latency/{}: {}", label, value));
-        }
-        data.sort();
-        let mut content = data.join("\n");
-        content += "\n";
-        let parts: Vec<&str> = content.split('/').collect();
-        parts.join("_")
-    }
 }


### PR DESCRIPTION
# Problem
We're looking to deprecate `rustcommon-fastmetrics` along with `rustcommon-metrics` and centralize on `rustcommon-metrics-v2` which avoids some of their downsides.

# Solution
This PR replaces all uses of `rustcommon-fastmetrics` with equivalent uses of `rustcommon-metrics-v2`-style metrics. 

One thing to note is that I've gone ahead and merged the duplicated definitions of `Admin` and `Snapshot` between `replay` and the main library. They were mostly identical so it only was necessary to add a few match statements around working with the config.

