### PR TITLE
ci: enable CI runs for PRs against any branch

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,8 +1,6 @@
 on:
   push:
   pull_request:
-    branches:
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,6 +1,4 @@
-on:
-  push:
-  pull_request:
+on: [ push, pull_request ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Currently, we're still working with a pre-release branch for 4.0.0
and should have CI enabled for PRs against that branch.

Changes the CI config to enable runs on PRs against any branch.