### PR TITLE
rpc-replay: add ratelimit based playback

### DIFF
--- a/src/replay.rs
+++ b/src/replay.rs
@@ -80,6 +80,13 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("rate")
+                .long("rate")
+                .value_name("INT")
+                .help("replay speed in requests/s")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("poolsize")
                 .long("poolsize")
                 .value_name("INT")


### PR DESCRIPTION
Currently, rpc-replay only allows speeds relative to the original cache trace. This PR adds a way to specify a request rate to apply a more constant load which doesn't have the varying request rates present in the trace. Aspects of the workload which are not dependent on timing are preserved (request mix, key distrubution, etc). 

This is useful in testing where we want to replay a cache-trace near instance red-line throughput.