### PR TITLE
memcache: add support for batch_size for GET requests

### DIFF
--- a/configs/memcache.toml
+++ b/configs/memcache.toml
@@ -26,3 +26,4 @@ commands = [
 length = 3
 values = [ { length = 16 } ]
 ttl = 0
+batch_size = 3

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -26,9 +26,16 @@ impl Memcache {
     }
 
     fn get(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut BytesMut) {
-        let key = keyspace.generate_key(rng);
         buf.extend_from_slice(b"get ");
-        buf.extend_from_slice(&key);
+
+        for i in 0..keyspace.batch_size() {
+            let key = keyspace.generate_key(rng);
+            buf.extend_from_slice(&key);
+            if i + 1 < keyspace.batch_size() {
+                buf.extend_from_slice(b" ");
+            }
+        }
+
         buf.extend_from_slice(b"\r\n");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Keyspace {
     value_dist: Option<WeightedAliasIndex<usize>>,
     ttl: usize,
     key_type: FieldType,
+    batch_size: usize,
 }
 
 impl Keyspace {
@@ -100,6 +101,10 @@ impl Keyspace {
     pub fn ttl(&self) -> usize {
         self.ttl
     }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
 }
 
 impl Config {
@@ -150,6 +155,7 @@ impl Config {
                 value_dist,
                 ttl: k.ttl(),
                 key_type: k.key_type(),
+                batch_size: k.batch_size(),
             };
             keyspaces.push(keyspace);
         }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -11,6 +11,7 @@ use std::net::ToSocketAddrs;
 use zookeeper::*;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigFile {
     general: General,
     target: Target,
@@ -89,6 +90,7 @@ fn alphanumeric() -> FieldType {
 
 #[derive(Deserialize, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
 pub enum FieldType {
     Alphanumeric,
     U32,
@@ -107,6 +109,7 @@ pub enum Protocol {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct General {
     protocol: Protocol,
     #[serde(default = "default_interval")]
@@ -147,6 +150,7 @@ impl General {
 }
 
 #[derive(Deserialize, Copy, Clone)]
+#[serde(deny_unknown_fields)]
 pub enum RatelimitModel {
     Smooth,
     Uniform,
@@ -154,6 +158,7 @@ pub enum RatelimitModel {
 }
 
 #[derive(Deserialize, Copy, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Connection {
     #[serde(default = "one")]
     poolsize: usize,
@@ -205,6 +210,7 @@ impl Connection {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Keyspace {
     #[serde(default = "one")]
     length: usize,
@@ -282,6 +288,7 @@ pub enum Verb {
 }
 
 #[derive(Deserialize, Copy, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Command {
     verb: Verb,
     #[serde(default = "one")]
@@ -299,6 +306,7 @@ impl Command {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct InnerKey {
     length: usize,
     #[serde(default = "one")]
@@ -322,6 +330,7 @@ impl InnerKey {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Value {
     length: usize,
     #[serde(default = "one")]
@@ -345,6 +354,7 @@ impl Value {
 }
 
 #[derive(Deserialize, Copy, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Request {
     timeout: Option<usize>,
     ratelimit: Option<usize>,
@@ -376,6 +386,7 @@ impl Request {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Tls {
     ca: String,
     cert: String,
@@ -409,6 +420,7 @@ impl Watcher for ExitWatcher {
 }
 
 #[derive(Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Target {
     endpoints: Vec<String>,
     zk_path: Option<String>,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -219,6 +219,8 @@ pub struct Keyspace {
     ttl: usize,
     #[serde(default = "alphanumeric")]
     key_type: FieldType,
+    #[serde(default = "one")]
+    batch_size: usize,
 }
 
 impl Keyspace {
@@ -249,6 +251,10 @@ impl Keyspace {
     pub fn key_type(&self) -> FieldType {
         self.key_type
     }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
 }
 
 #[derive(Deserialize, Clone, Copy, Eq, PartialEq)]
@@ -259,7 +265,8 @@ pub enum Verb {
     Ping,
     /// Sends a payload with a CRC to an echo server and checks for corruption.
     Echo,
-    /// Simple key-value get which reads the value for a key.
+    /// Simple key-value get which reads the value for one or more keys
+    /// depending on the batch size.
     Get,
     /// Simple key-value set which will overwrite the value for a key.
     Set,


### PR DESCRIPTION
Adds the ability to specify a batch_size for a keyspace and send
multiple keys in the same memcache GET request.
