### PR TITLE
codec: add thrift cache support to 4.x

### DIFF
--- a/configs/memcache.toml
+++ b/configs/memcache.toml
@@ -1,28 +1,47 @@
 [general]
+# specify the protocol to be used
 protocol = "memcache"
+# the interval for stats integration and reporting
 interval = 60
+# the number of intervals to run the test for
 windows = 5
+# when service is true, the runtime is unlimited
 service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
 admin = "127.0.0.1:9090"
 
 [target]
+# specify one or more endpoints as IP:PORT pairs
 endpoints = [
 	"127.0.0.1:11211"
 ]
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 12 },
-	{ verb = "set", weight = 3 },
+	{ verb = "get", weight = 4 },
+	{ verb = "set", weight = 1 },
 ]
+# the length of the key in bytes, keyspace will be: 52^N keys
 length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
 values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
 ttl = 0
-batch_size = 3
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of keys in a `get` request
+batch_size = 1

--- a/configs/memcache_zookeeper.toml
+++ b/configs/memcache_zookeeper.toml
@@ -1,26 +1,49 @@
 [general]
+# specify the protocol to be used
 protocol = "memcache"
-interval = 1
-service = true
+# the interval for stats integration and reporting
+interval = 60
+# the number of intervals to run the test for
+windows = 5
+# when service is true, the runtime is unlimited
+service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
+admin = "127.0.0.1:9090"
 
 [target]
+# connect to the provided zookeeper server
 zk_server = "zookeeper"
+# the path of the service nodes in zookeeper
 zk_path = "service/role/env/job"
+# the name of the endpoint within the node
 zk_endpoint_name = "serviceEndpoint"
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
-
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
 	{ verb = "get", weight = 4 },
 	{ verb = "set", weight = 1 },
 ]
+# the length of the key in bytes, keyspace will be: 52^N keys
 length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
 values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
 ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of keys in a `get` request
+batch_size = 1

--- a/configs/pelikan.toml
+++ b/configs/pelikan.toml
@@ -1,27 +1,47 @@
 [general]
+# specify the protocol to be used
 protocol = "memcache"
+# the interval for stats integration and reporting
 interval = 60
+# the number of intervals to run the test for
 windows = 5
+# when service is true, the runtime is unlimited
 service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
 admin = "127.0.0.1:9090"
 
 [target]
+# specify one or more endpoints as IP:PORT pairs
 endpoints = [
 	"127.0.0.1:12321"
 ]
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
 	{ verb = "get", weight = 4 },
 	{ verb = "set", weight = 1 },
 ]
+# the length of the key in bytes, keyspace will be: 52^N keys
 length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
 values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
 ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of keys in a `get` request
+batch_size = 1

--- a/configs/ping.toml
+++ b/configs/ping.toml
@@ -1,23 +1,36 @@
 [general]
+# specify the protocol to be used
 protocol = "ping"
+# the interval for stats integration and reporting
 interval = 60
+# the number of intervals to run the test for
 windows = 5
+# when service is true, the runtime is unlimited
 service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
 admin = "127.0.0.1:9090"
 
 [target]
+# specify one or more endpoints as IP:PORT pairs
 endpoints = [
 	"127.0.0.1:12321"
 ]
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
-	{ verb = "ping" }
+	{ verb = "ping", weight = 1 },
 ]

--- a/configs/thrift_cache_hash.toml
+++ b/configs/thrift_cache_hash.toml
@@ -1,0 +1,48 @@
+[general]
+# specify the protocol to be used
+protocol = "thrift_cache"
+# the interval for stats integration and reporting
+interval = 60
+# the number of intervals to run the test for
+windows = 5
+# when service is true, the runtime is unlimited
+service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
+threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
+admin = "127.0.0.1:9090"
+
+[target]
+# specify one or more endpoints as IP:PORT pairs
+endpoints = [
+	"127.0.0.1:11211"
+]
+
+[connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
+poolsize = 25
+
+[request]
+# set a global ratelimit for requests
+ratelimit = 50000
+
+[[keyspace]]
+# controls what commands will be used in this keyspace
+commands = [
+	{ verb = "hget", weight = 4 },
+	{ verb = "hset", weight = 1 },
+	{ verb = "hdel", weight = 1 },
+]
+# the length of the key in bytes, keyspace will be: 52^N keys
+length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
+values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
+ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of fields in a `hget` request
+batch_size = 1

--- a/configs/thrift_cache_list.toml
+++ b/configs/thrift_cache_list.toml
@@ -1,0 +1,49 @@
+[general]
+# specify the protocol to be used
+protocol = "thrift_cache"
+# the interval for stats integration and reporting
+interval = 60
+# the number of intervals to run the test for
+windows = 5
+# when service is true, the runtime is unlimited
+service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
+threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
+admin = "127.0.0.1:9090"
+
+[target]
+# specify one or more endpoints as IP:PORT pairs
+endpoints = [
+	"127.0.0.1:11211"
+]
+
+[connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
+poolsize = 25
+
+[request]
+# set a global ratelimit for requests
+ratelimit = 50000
+
+[[keyspace]]
+# controls what commands will be used in this keyspace
+commands = [
+	{ verb = "lrange", weight = 4 },
+	{ verb = "rpush", weight = 1 },
+	{ verb = "rpushx", weight = 1 },
+	{ verb = "ltrim", weight = 1 },
+]
+# the length of the key in bytes, keyspace will be: 52^N keys
+length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
+values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
+ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of field-value pairs in an `rpush` command
+batch_size = 1

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -6,12 +6,15 @@ mod echo;
 mod memcache;
 mod ping;
 mod redis;
+mod thrift;
+mod thrift_cache;
 
 use crate::Session;
 pub use echo::Echo;
 pub use memcache::Memcache;
 pub use ping::Ping;
 pub use redis::Redis;
+pub use thrift_cache::ThriftCache;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParseError {

--- a/src/codec/thrift.rs
+++ b/src/codec/thrift.rs
@@ -1,0 +1,193 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#![allow(dead_code)]
+
+use crate::codec::ParseError;
+
+pub const STOP: u8 = 0;
+pub const VOID: u8 = 1;
+pub const BOOL: u8 = 2;
+pub const BYTE: u8 = 3;
+pub const DOUBLE: u8 = 4;
+pub const I16: u8 = 6;
+pub const I32: u8 = 8;
+pub const I64: u8 = 10;
+pub const STRING: u8 = 11;
+pub const STRUCT: u8 = 12;
+pub const MAP: u8 = 13;
+pub const SET: u8 = 14;
+pub const LIST: u8 = 15;
+
+#[derive(Clone)]
+pub struct ThriftBuffer {
+    buffer: Vec<u8>,
+}
+
+impl Default for ThriftBuffer {
+    fn default() -> Self {
+        let mut buffer = Vec::<u8>::new();
+        buffer.resize(4, 0);
+
+        Self { buffer }
+    }
+}
+
+impl ThriftBuffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// add protocol version to buffer
+    pub fn protocol_header(&mut self) -> &Self {
+        self.buffer.extend_from_slice(&[128, 1, 0, 1]);
+        self
+    }
+
+    /// write the framed length to the buffer
+    #[inline]
+    pub fn frame(&mut self) -> &Self {
+        let bytes = self.buffer.len() - 4;
+        for (p, i) in (bytes as i32).to_be_bytes().iter().enumerate() {
+            self.buffer[p] = *i;
+        }
+        self
+    }
+
+    /// add method name to buffer
+    #[inline]
+    pub fn method_name(&mut self, method: &str) -> &Self {
+        self.write_str(method)
+    }
+
+    /// add sequence id to buffer
+    #[inline]
+    pub fn sequence_id(&mut self, id: i32) -> &Self {
+        self.write_i32(id as i32)
+    }
+
+    /// add stop sequence to buffer
+    pub fn stop(&mut self) -> &Self {
+        self.write_bytes(&[STOP])
+    }
+
+    // write an i16 to the buffer
+    #[inline]
+    pub fn write_i16(&mut self, value: i16) -> &Self {
+        self.buffer.extend_from_slice(&value.to_be_bytes());
+        self
+    }
+
+    // write an i32 to the buffer
+    #[inline]
+    pub fn write_i32(&mut self, value: i32) -> &Self {
+        self.buffer.extend_from_slice(&value.to_be_bytes());
+        self
+    }
+
+    // write an i64 to the buffer
+    #[inline]
+    pub fn write_i64(&mut self, value: i64) -> &Self {
+        self.buffer.extend_from_slice(&value.to_be_bytes());
+        self
+    }
+
+    // write a literal byte sequence to the buffer
+    #[inline]
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> &Self {
+        self.buffer.extend_from_slice(bytes);
+        self
+    }
+
+    // write bool to the buffer
+    #[inline]
+    pub fn write_bool(&mut self, b: bool) -> &Self {
+        self.buffer.extend_from_slice(&[(b as u8)]);
+        self
+    }
+
+    #[inline]
+    pub fn write_str(&mut self, string: &str) -> &Self {
+        let string = string.as_bytes();
+        self.write_i32(string.len() as i32);
+        self.buffer.extend_from_slice(string);
+        self
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+fn decode(buf: &[u8]) -> Result<(), ParseError> {
+    let bytes = buf.len() as u32;
+    if bytes > 4 {
+        let length = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+
+        match length.checked_add(4_u32) {
+            Some(b) => {
+                if b == bytes {
+                    Ok(())
+                } else {
+                    Err(ParseError::Incomplete)
+                }
+            }
+            None => Err(ParseError::Unknown),
+        }
+    } else {
+        Err(ParseError::Incomplete)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ping() {
+        let mut buffer = ThriftBuffer::new();
+
+        // new buffer has 4 bytes to hold framing later
+        assert_eq!(buffer.len(), 4);
+        assert_eq!(buffer.as_bytes(), &[0, 0, 0, 0]);
+
+        buffer.protocol_header();
+        assert_eq!(buffer.len(), 8);
+        assert_eq!(buffer.as_bytes(), &[0, 0, 0, 0, 128, 1, 0, 1]);
+
+        buffer.method_name("ping");
+        assert_eq!(buffer.len(), 16);
+        assert_eq!(
+            buffer.as_bytes(),
+            &[0, 0, 0, 0, 128, 1, 0, 1, 0, 0, 0, 4, 112, 105, 110, 103]
+        );
+
+        buffer.sequence_id(0);
+        assert_eq!(buffer.len(), 20);
+        assert_eq!(
+            buffer.as_bytes(),
+            &[0, 0, 0, 0, 128, 1, 0, 1, 0, 0, 0, 4, 112, 105, 110, 103, 0, 0, 0, 0]
+        );
+
+        buffer.stop();
+        assert_eq!(buffer.len(), 21);
+        assert_eq!(
+            buffer.as_bytes(),
+            &[0, 0, 0, 0, 128, 1, 0, 1, 0, 0, 0, 4, 112, 105, 110, 103, 0, 0, 0, 0, 0]
+        );
+
+        buffer.frame();
+        assert_eq!(buffer.len(), 21);
+        assert_eq!(
+            buffer.as_bytes(),
+            &[0, 0, 0, 17, 128, 1, 0, 1, 0, 0, 0, 4, 112, 105, 110, 103, 0, 0, 0, 0, 0]
+        );
+
+        assert_eq!(decode(buffer.as_bytes()), Ok(()));
+    }
+}

--- a/src/codec/thrift_cache.rs
+++ b/src/codec/thrift_cache.rs
@@ -1,0 +1,591 @@
+// Copyright 2022 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::thrift;
+
+use crate::codec::*;
+use crate::config::*;
+use crate::config_file::Verb;
+use crate::*;
+
+use std::io::Write;
+
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+pub struct ThriftCache {
+    config: Arc<Config>,
+    rng: SmallRng,
+}
+
+impl ThriftCache {
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            rng: SmallRng::from_entropy(),
+        }
+    }
+
+    fn append(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut values = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            values.push(keyspace.generate_value(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("append");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(3);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(values.len() as i32);
+
+        for value in values {
+            buffer.write_i32(value.len() as i32);
+            buffer.write_bytes(&value);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn appendx(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut values = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            values.push(keyspace.generate_value(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("appendx");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(3);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(values.len() as i32);
+
+        for value in values {
+            buffer.write_i32(value.len() as i32);
+            buffer.write_bytes(&value);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn count(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let timeout = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("count");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn get(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut fields = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let timeout = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("get");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(3);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(fields.len() as i32);
+
+        for field in fields {
+            buffer.write_i32(field.len() as i32);
+            buffer.write_bytes(&field);
+        }
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn put(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut fields = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let mut values = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            values.push(keyspace.generate_value(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let timeout = None;
+        let timestamp = None;
+        let ttl = keyspace.ttl();
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("put");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(3);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(fields.len() as i32);
+
+        for field in fields {
+            buffer.write_i32(field.len() as i32);
+            buffer.write_bytes(&field);
+        }
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(4);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(values.len() as i32);
+
+        for value in values {
+            buffer.write_i32(value.len() as i32);
+            buffer.write_bytes(&value);
+        }
+
+        if let Some(timestamp) = timestamp {
+            buffer.write_bytes(&[thrift::I64]);
+            buffer.write_i16(5);
+            buffer.write_i64(timestamp);
+        }
+
+        if ttl > 0 {
+            buffer.write_bytes(&[thrift::I64]);
+            buffer.write_i16(6);
+            buffer.write_i64(ttl as i64);
+        }
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn remove(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut fields = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let timeout = None;
+        let timestamp = None;
+        let count = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("remove");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(3);
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i32(fields.len() as i32);
+
+        for field in fields {
+            buffer.write_i32(field.len() as i32);
+            buffer.write_bytes(&field);
+        }
+
+        if let Some(timestamp) = timestamp {
+            buffer.write_bytes(&[thrift::I64]);
+            buffer.write_i16(4);
+            buffer.write_i64(timestamp);
+        }
+
+        if let Some(count) = count {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(5);
+            buffer.write_i32(count);
+        }
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn range(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let mut fields = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let mut values = Vec::new();
+        for _ in 0..keyspace.batch_size() {
+            values.push(keyspace.generate_value(rng).unwrap_or_else(|| b"".to_vec()));
+        }
+        let start = None;
+        let stop = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("range");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        if let Some(start) = start {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(3);
+            buffer.write_i32(start);
+        }
+
+        if let Some(stop) = stop {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(4);
+            buffer.write_i32(stop);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    #[allow(dead_code)]
+    fn scan(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let start_field = None;
+        let end_field = None;
+        let ascending = None;
+        let limit = None;
+        let timeout = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("scan");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        if let Some(start_field) = start_field {
+            buffer.write_bytes(&[thrift::STRING]);
+            buffer.write_i16(3);
+            buffer.write_bytes(start_field);
+        }
+
+        if let Some(end_field) = end_field {
+            buffer.write_bytes(&[thrift::STRING]);
+            buffer.write_i16(4);
+            buffer.write_bytes(end_field);
+        }
+
+        if let Some(ascending) = ascending {
+            buffer.write_bytes(&[thrift::BOOL]);
+            buffer.write_i16(5);
+            buffer.write_bool(ascending);
+        }
+
+        if let Some(limit) = limit {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(6);
+            buffer.write_i32(limit);
+        }
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+
+    fn trim(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let target_size = 1;
+        let trim_from_smallest = true;
+        let timeout = None;
+
+        let mut buffer = thrift::ThriftBuffer::new();
+        buffer.protocol_header();
+        buffer.method_name("range");
+        buffer.sequence_id(0);
+
+        buffer.write_bytes(&[thrift::LIST]);
+        buffer.write_i16(1);
+        buffer.write_bytes(&[thrift::STRUCT]);
+        buffer.write_i32(1);
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(1);
+        buffer.write_i32(1);
+        buffer.write_bytes(b"0");
+
+        buffer.write_bytes(&[thrift::STRING]);
+        buffer.write_i16(2);
+        buffer.write_i32(key.len() as i32);
+        buffer.write_bytes(&key);
+
+        buffer.write_bytes(&[thrift::I32]);
+        buffer.write_i16(3);
+        buffer.write_i32(target_size);
+
+        buffer.write_bytes(&[thrift::BOOL]);
+        buffer.write_i16(4);
+        buffer.write_bool(trim_from_smallest);
+
+        if let Some(timeout) = timeout {
+            buffer.write_bytes(&[thrift::I32]);
+            buffer.write_i16(11);
+            buffer.write_i32(timeout);
+        }
+
+        // stop request struct
+        buffer.stop();
+
+        buffer.stop();
+        buffer.frame();
+
+        let _ = buf.write(buffer.as_bytes());
+    }
+}
+
+impl Codec for ThriftCache {
+    fn encode(&mut self, buf: &mut Session) {
+        let keyspace = self.config.choose_keyspace(&mut self.rng);
+        let command = keyspace.choose_command(&mut self.rng);
+        match command.verb() {
+            Verb::Rpush => {
+                Self::append(&mut self.rng, keyspace, buf)
+            }
+            Verb::Rpushx => {
+                Self::appendx(&mut self.rng, keyspace, buf)
+            }
+            Verb::Count => {
+                Self::count(&mut self.rng, keyspace, buf)
+            }
+            Verb::Hget => {
+                Self::get(&mut self.rng, keyspace, buf)
+            }
+            Verb::Hset => {
+                Self::put(&mut self.rng, keyspace, buf)
+            }
+            Verb::Hdel => {
+                Self::remove(&mut self.rng, keyspace, buf)
+            }
+            Verb::Lrange => {
+                Self::range(&mut self.rng, keyspace, buf)
+            }
+            Verb::Ltrim => {
+                Self::trim(&mut self.rng, keyspace, buf)
+            }
+            _ => {
+                unimplemented!()
+            }
+        }
+    }
+
+    fn decode(&self, buffer: &mut Session) -> Result<(), ParseError> {
+        // no-copy borrow as a slice
+        let buf: &[u8] = (*buffer).buffer();
+
+        let bytes = buf.len() as u32;
+        if bytes > 4 {
+            let length = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+
+            match length.checked_add(4_u32) {
+                Some(b) => {
+                    if b == bytes {
+                        Ok(())
+                    } else {
+                        Err(ParseError::Incomplete)
+                    }
+                }
+                None => Err(ParseError::Unknown),
+            }
+        } else {
+            Err(ParseError::Incomplete)
+        }
+    }
+}

--- a/src/codec/thrift_cache.rs
+++ b/src/codec/thrift_cache.rs
@@ -162,7 +162,11 @@ impl ThriftCache {
         let key = keyspace.generate_key(rng);
         let mut fields = Vec::new();
         for _ in 0..keyspace.batch_size() {
-            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+            fields.push(
+                keyspace
+                    .generate_inner_key(rng)
+                    .unwrap_or_else(|| b"".to_vec()),
+            );
         }
         let timeout = None;
 
@@ -215,7 +219,11 @@ impl ThriftCache {
         let key = keyspace.generate_key(rng);
         let mut fields = Vec::new();
         for _ in 0..keyspace.batch_size() {
-            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+            fields.push(
+                keyspace
+                    .generate_inner_key(rng)
+                    .unwrap_or_else(|| b"".to_vec()),
+            );
         }
         let mut values = Vec::new();
         for _ in 0..keyspace.batch_size() {
@@ -296,7 +304,11 @@ impl ThriftCache {
         let key = keyspace.generate_key(rng);
         let mut fields = Vec::new();
         for _ in 0..keyspace.batch_size() {
-            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+            fields.push(
+                keyspace
+                    .generate_inner_key(rng)
+                    .unwrap_or_else(|| b"".to_vec()),
+            );
         }
         let timeout = None;
         let timestamp = None;
@@ -363,7 +375,11 @@ impl ThriftCache {
         let key = keyspace.generate_key(rng);
         let mut fields = Vec::new();
         for _ in 0..keyspace.batch_size() {
-            fields.push(keyspace.generate_inner_key(rng).unwrap_or_else(|| b"".to_vec()));
+            fields.push(
+                keyspace
+                    .generate_inner_key(rng)
+                    .unwrap_or_else(|| b"".to_vec()),
+            );
         }
         let mut values = Vec::new();
         for _ in 0..keyspace.batch_size() {
@@ -536,30 +552,14 @@ impl Codec for ThriftCache {
         let keyspace = self.config.choose_keyspace(&mut self.rng);
         let command = keyspace.choose_command(&mut self.rng);
         match command.verb() {
-            Verb::Rpush => {
-                Self::append(&mut self.rng, keyspace, buf)
-            }
-            Verb::Rpushx => {
-                Self::appendx(&mut self.rng, keyspace, buf)
-            }
-            Verb::Count => {
-                Self::count(&mut self.rng, keyspace, buf)
-            }
-            Verb::Hget => {
-                Self::get(&mut self.rng, keyspace, buf)
-            }
-            Verb::Hset => {
-                Self::put(&mut self.rng, keyspace, buf)
-            }
-            Verb::Hdel => {
-                Self::remove(&mut self.rng, keyspace, buf)
-            }
-            Verb::Lrange => {
-                Self::range(&mut self.rng, keyspace, buf)
-            }
-            Verb::Ltrim => {
-                Self::trim(&mut self.rng, keyspace, buf)
-            }
+            Verb::Rpush => Self::append(&mut self.rng, keyspace, buf),
+            Verb::Rpushx => Self::appendx(&mut self.rng, keyspace, buf),
+            Verb::Count => Self::count(&mut self.rng, keyspace, buf),
+            Verb::Hget => Self::get(&mut self.rng, keyspace, buf),
+            Verb::Hset => Self::put(&mut self.rng, keyspace, buf),
+            Verb::Hdel => Self::remove(&mut self.rng, keyspace, buf),
+            Verb::Lrange => Self::range(&mut self.rng, keyspace, buf),
+            Verb::Ltrim => Self::trim(&mut self.rng, keyspace, buf),
             _ => {
                 unimplemented!()
             }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -106,6 +106,7 @@ pub enum Protocol {
     Redis,
     RedisInline,
     RedisResp,
+    ThriftCache,
 }
 
 #[derive(Deserialize, Clone)]
@@ -278,13 +279,30 @@ pub enum Verb {
     Set,
     /// Remove a key.
     Delete,
-    /// Hash get, reads the value for a field within the hash stored at the key.
+    /// Hash get, reads the value for one or more fields within the hash stored
+    /// at the key.
     Hget,
     /// Hash set, set the value for a field within the hash stored at the key.
     Hset,
     /// Hash set non-existing, set the value for a field within the hash stored
     /// at the key only if the field does not exist.
     Hsetnx,
+    /// Deletes one or more fields from the hash stored at the key
+    Hdel,
+    /// Insert all the specified values at the tail of the list stored at a key.
+    /// Creates a new key if the key does not exist. Returns an error if the key
+    /// contains a value which is not a list.
+    Rpush,
+    /// Insert all the specified values at the tail of the list stored at a key,
+    /// returns an error if the key does not exist or contains a value which is
+    /// not a list.
+    Rpushx,
+    /// Count the number of items stored at a key
+    Count,
+    /// Returns the elements of the list stored at the key
+    Lrange,
+    /// Trims the elements of the list sotred at the key
+    Ltrim,
 }
 
 #[derive(Deserialize, Copy, Clone)]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -79,6 +79,7 @@ impl Worker {
             Protocol::Redis | Protocol::RedisInline | Protocol::RedisResp => {
                 Box::new(Redis::new(config.clone())) as Box<dyn Codec>
             }
+            Protocol::ThriftCache => Box::new(ThriftCache::new(config.clone())) as Box<dyn Codec>,
         };
 
         // return the worker


### PR DESCRIPTION
Adds `ThriftCache` protocol support to the 4.x branch. Defines additional commands that are supported by the protocol.

Include more comments in the example configs.