### PR TITLE
fix redis response handling

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -188,3 +188,24 @@ jobs:
       - name: Smoketest
         run: rpc-perf/target/release/rpc-perf rpc-perf/configs/ping.toml
 
+  pelikan-segcache-smoketest:
+    name: pelikan segcache smoketest
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            path: rpc-perf
+      - uses: Swatinem/rust-cache@v1
+      - name: Checkout Pelikan
+        uses: actions/checkout@v2
+        with:
+          repository: twitter/pelikan
+          path: pelikan
+      - name: Build Pelikan
+        run: cd pelikan && cargo build --release
+      - name: Build rpc-perf
+        run: cd rpc-perf && cargo build --release
+      - name: Run Pelikan Segcache
+        run: pelikan/target/release/pelikan_segcache_rs &
+      - name: Smoketest
+        run: rpc-perf/target/release/rpc-perf rpc-perf/configs/pelikan.toml

--- a/configs/memcache.toml
+++ b/configs/memcache.toml
@@ -32,8 +32,9 @@ ratelimit = 50000
 [[keyspace]]
 # controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 4 },
-	{ verb = "set", weight = 1 },
+	{ verb = "get", weight = 8 },
+	{ verb = "set", weight = 2 },
+	{ verb = "delete", weight = 1 },
 ]
 # the length of the key in bytes, keyspace will be: 52^N keys
 length = 3

--- a/configs/memcache_zookeeper.toml
+++ b/configs/memcache_zookeeper.toml
@@ -34,8 +34,9 @@ ratelimit = 50000
 [[keyspace]]
 # controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 4 },
-	{ verb = "set", weight = 1 },
+	{ verb = "get", weight = 8 },
+	{ verb = "set", weight = 2 },
+	{ verb = "delete", weight = 1 },
 ]
 # the length of the key in bytes, keyspace will be: 52^N keys
 length = 3

--- a/configs/pelikan.toml
+++ b/configs/pelikan.toml
@@ -32,8 +32,9 @@ ratelimit = 50000
 [[keyspace]]
 # controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 4 },
-	{ verb = "set", weight = 1 },
+	{ verb = "get", weight = 8 },
+	{ verb = "set", weight = 2 },
+	{ verb = "delete", weight = 1 },
 ]
 # the length of the key in bytes, keyspace will be: 52^N keys
 length = 3

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -1,37 +1,48 @@
 [general]
+# specify the protocol to be used
 protocol = "redis"
+# the interval for stats integration and reporting
 interval = 60
+# the number of intervals to run the test for
 windows = 5
+# when service is true, the runtime is unlimited
 service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
 admin = "127.0.0.1:9090"
 
 [target]
+# specify one or more endpoints as IP:PORT pairs
 endpoints = [
 	"127.0.0.1:6379"
 ]
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 4 },
-	{ verb = "set", weight = 1 },
-]
-length = 3
-values = [ { length = 16 } ]
-ttl = 0
-
-[[keyspace]]
-commands = [
-	{ verb = "hget", weight = 4 },
-	{ verb = "hset", weight = 2 },
+	{ verb = "get", weight = 8 },
+	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-length = 2
-inner_keys = [ { length = 2 }]
-values = [ { length = 8 }]
+# the length of the key in bytes, keyspace will be: 52^N keys
+length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
+values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
+ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of keys in a `get` request
+batch_size = 1

--- a/configs/redis_resp.toml
+++ b/configs/redis_resp.toml
@@ -1,27 +1,48 @@
 [general]
+# specify the protocol to be used
 protocol = "redis_resp"
+# the interval for stats integration and reporting
 interval = 60
+# the number of intervals to run the test for
 windows = 5
+# when service is true, the runtime is unlimited
 service = false
+# controls the number of worker threads to launch, each worker thread maintains
+# its own event loop and connection pool to each endpoint
 threads = 4
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
 admin = "127.0.0.1:9090"
 
 [target]
+# specify one or more endpoints as IP:PORT pairs
 endpoints = [
 	"127.0.0.1:6379"
 ]
 
 [connection]
+# the number of connections to each endpoint from each thread, the total number
+# of connections to each endpoint is: poolsize * threads
 poolsize = 25
 
 [request]
+# set a global ratelimit for requests
 ratelimit = 50000
 
 [[keyspace]]
+# controls what commands will be used in this keyspace
 commands = [
-	{ verb = "get", weight = 4 },
-	{ verb = "set", weight = 1 },
+	{ verb = "get", weight = 8 },
+	{ verb = "set", weight = 2 },
+	{ verb = "delete", weight = 1 },
 ]
+# the length of the key in bytes, keyspace will be: 52^N keys
 length = 3
+# controls how values will be generated, multiple lengths with varying weights
+# can be specified here
 values = [ { length = 16 } ]
+# provide a time-to-live for items in this keyspace
 ttl = 0
+# controls the cardinality of commands which operate on more than one item in
+# a single request, eg: the number of keys in a `get` request
+batch_size = 1

--- a/configs/thrift_cache_hash.toml
+++ b/configs/thrift_cache_hash.toml
@@ -32,8 +32,8 @@ ratelimit = 50000
 [[keyspace]]
 # controls what commands will be used in this keyspace
 commands = [
-	{ verb = "hget", weight = 4 },
-	{ verb = "hset", weight = 1 },
+	{ verb = "hget", weight = 8 },
+	{ verb = "hset", weight = 2 },
 	{ verb = "hdel", weight = 1 },
 ]
 # the length of the key in bytes, keyspace will be: 52^N keys

--- a/src/codec/memcache.rs
+++ b/src/codec/memcache.rs
@@ -49,6 +49,13 @@ impl Memcache {
         let _ = buf.write_all(&value);
         let _ = buf.write_all(b"\r\n");
     }
+
+    fn delete(rng: &mut SmallRng, keyspace: &Keyspace, buf: &mut Session) {
+        let key = keyspace.generate_key(rng);
+        let _ = buf.write_all(b"delete ");
+        let _ = buf.write_all(&key);
+        let _ = buf.write_all(b"\r\n");
+    }
 }
 
 impl Codec for Memcache {
@@ -61,6 +68,7 @@ impl Codec for Memcache {
                 Self::get(&mut self.rng, keyspace, buf)
             }
             Verb::Set => Self::set(&mut self.rng, keyspace, buf),
+            Verb::Delete => Self::delete(&mut self.rng, keyspace, buf),
             _ => {
                 unimplemented!()
             }

--- a/src/codec/redis.rs
+++ b/src/codec/redis.rs
@@ -213,7 +213,7 @@ impl Codec for Redis {
                             let response_end = buf.len();
                             let _ = buffer.consume(response_end);
                             Ok(())
-                        },
+                        }
                         Err(_) => Err(ParseError::Unknown),
                     },
                     Err(_) => Err(ParseError::Unknown),

--- a/src/codec/redis.rs
+++ b/src/codec/redis.rs
@@ -209,7 +209,11 @@ impl Codec for Redis {
                 let msg = &buf[1..buf.len() - 2];
                 match str::from_utf8(msg) {
                     Ok(msg) => match msg.parse::<i64>() {
-                        Ok(_) => Ok(()),
+                        Ok(_) => {
+                            let response_end = buf.len();
+                            let _ = buffer.consume(response_end);
+                            Ok(())
+                        },
                         Err(_) => Err(ParseError::Unknown),
                     },
                     Err(_) => Err(ParseError::Unknown),


### PR DESCRIPTION
Problem

Redis coded fails to consume response bytes for numeric response.

This results in buffer corruption and connection churn.

Solution

Consume the response bytes for numeric response.

Result

Smoketests show no connection churn in CI.