### PR TITLE
ci: build caching for Pelikan smoketests

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -195,7 +195,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
             path: rpc-perf
-      - uses: Swatinem/rust-cache@v1
+      - name: Build Cache for rpc-perf
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: rpc-perf
+          working-directory: rpc-perf
+      - name: Build Cache for Pelikan
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: pelikan
+          working-directory: pelikan
       - name: Checkout Pelikan
         uses: actions/checkout@v2
         with:
@@ -217,7 +226,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
             path: rpc-perf
-      - uses: Swatinem/rust-cache@v1
+      - name: Build Cache for rpc-perf
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: rpc-perf
+          working-directory: rpc-perf
+      - name: Build Cache for Pelikan
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: pelikan
+          working-directory: pelikan
       - name: Checkout Pelikan
         uses: actions/checkout@v2
         with:
@@ -269,7 +287,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
             path: rpc-perf
-      - uses: Swatinem/rust-cache@v1
+      - name: Build Cache for rpc-perf
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: rpc-perf
+          working-directory: rpc-perf
+      - name: Build Cache for Pelikan
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: pelikan
+          working-directory: pelikan
       - name: Checkout Pelikan
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Current build caching doesn't work for the Pelikan smoketests
because we use non-standard paths to allow building both rpc-perf
and Pelikan during the smoketest.

This change splits the caching action into two seperate actions so
that Pelikan and rpc-perf will each benefit from their own build
cache during these smoketests. Should reduce the CI time
considerably.
