### PR TITLE
fix: fix issue introduced in #363

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -423,7 +423,7 @@ impl Snapshot {
                 ));
             }
         }
-        for (gauge, entry) in &self.counters {
+        for (gauge, entry) in &self.gauges {
             if let Some(description) = entry.description {
                 data.push(format!(
                     "# HELP {} {}\n# TYPE {} gauge\n{} {}",


### PR DESCRIPTION
PR #363 added metrics descriptions, but mistakenly iterates through
the counters twice for prometheus/opentelemetry format and
incorrectly reports each counter as both a counter and a gauge.

Fixes a bad copy-paste from that PR.
