### PR TITLE
fix: thrift cache protocol

### DIFF
--- a/src/codec/thrift_cache.rs
+++ b/src/codec/thrift_cache.rs
@@ -3,6 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use super::thrift;
+use std::io::BufRead;
 
 use crate::codec::*;
 use crate::config::*;
@@ -577,6 +578,7 @@ impl Codec for ThriftCache {
             match length.checked_add(4_u32) {
                 Some(b) => {
                     if b == bytes {
+                        buffer.consume(b as usize);
                         Ok(())
                     } else {
                         Err(ParseError::Incomplete)


### PR DESCRIPTION
Fixes a bug in the thrift cache protocol where bytes were not
consumed from the buffer after receiving a response. This leads to
subsequent requests getting stuck in the incomplete response state.

Changes the decode logic to consume the bytes to fix the bug.
