### PR TITLE
Add cardinality to U32 key/value configs

### DIFF
--- a/configs/memcache.toml
+++ b/configs/memcache.toml
@@ -59,7 +59,8 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will 
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/memcache_zookeeper.toml
+++ b/configs/memcache_zookeeper.toml
@@ -61,7 +61,8 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/memcache_zookeeper.toml
+++ b/configs/memcache_zookeeper.toml
@@ -61,7 +61,7 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/pelikan.toml
+++ b/configs/pelikan.toml
@@ -62,7 +62,8 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/pelikan.toml
+++ b/configs/pelikan.toml
@@ -62,7 +62,7 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -59,7 +59,7 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -59,7 +59,8 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/redis_resp.toml
+++ b/configs/redis_resp.toml
@@ -59,7 +59,7 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/redis_resp.toml
+++ b/configs/redis_resp.toml
@@ -59,7 +59,8 @@ commands = [
 	{ verb = "set", weight = 2 },
 	{ verb = "delete", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/thrift_cache_hash.toml
+++ b/configs/thrift_cache_hash.toml
@@ -59,7 +59,8 @@ commands = [
 	{ verb = "hset", weight = 2 },
 	{ verb = "hdel", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/thrift_cache_hash.toml
+++ b/configs/thrift_cache_hash.toml
@@ -59,7 +59,7 @@ commands = [
 	{ verb = "hset", weight = 2 },
 	{ verb = "hdel", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/thrift_cache_list.toml
+++ b/configs/thrift_cache_list.toml
@@ -60,7 +60,8 @@ commands = [
 	{ verb = "rpushx", weight = 1 },
 	{ verb = "ltrim", weight = 1 },
 ]
-# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will
+# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/configs/thrift_cache_list.toml
+++ b/configs/thrift_cache_list.toml
@@ -60,7 +60,7 @@ commands = [
 	{ verb = "rpushx", weight = 1 },
 	{ verb = "ltrim", weight = 1 },
 ]
-# the length of the key in bytes, keyspace will be: 52^N keys
+# the length of the key in bytes, for alphanumeric fields, the keyspace will# be: 52^N keys
 length = 3
 # controls how values will be generated, multiple lengths with varying weights
 # can be specified here

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,13 @@ impl Keyspace {
                 .sample_iter(&Alphanumeric)
                 .take(self.length())
                 .collect::<Vec<u8>>(),
-            FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..self.cardinality()), len=self.length()).as_bytes().to_vec(),
+            FieldType::U32 => format!(
+                "{:0>len$}",
+                &rng.gen_range(0u32..self.cardinality()),
+                len = self.length()
+            )
+            .as_bytes()
+            .to_vec(),
         }
     }
 
@@ -70,7 +76,13 @@ impl Keyspace {
                     .sample_iter(&Alphanumeric)
                     .take(conf.length())
                     .collect::<Vec<u8>>(),
-                FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..conf.cardinality()), len=conf.length()).as_bytes().to_vec(),
+                FieldType::U32 => format!(
+                    "{:0>len$}",
+                    &rng.gen_range(0u32..conf.cardinality()),
+                    len = conf.length()
+                )
+                .as_bytes()
+                .to_vec(),
             };
             Some(inner_key)
         } else {
@@ -88,7 +100,13 @@ impl Keyspace {
                     .sample_iter(&Alphanumeric)
                     .take(value_conf.length())
                     .collect::<Vec<u8>>(),
-                FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..value_conf.cardinality()), len=value_conf.length()).as_bytes().to_vec(),
+                FieldType::U32 => format!(
+                    "{:0>len$}",
+                    &rng.gen_range(0u32..value_conf.cardinality()),
+                    len = value_conf.length()
+                )
+                .as_bytes()
+                .to_vec(),
             };
             Some(value)
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Keyspace {
         self.cardinality
     }
 
-    //TODO(aetimmes): implement cardinality for Alphanumeric fields
+    // TODO(aetimmes): implement cardinality for Alphanumeric fields
     pub fn generate_key(&self, rng: &mut SmallRng) -> Vec<u8> {
         match self.key_type {
             FieldType::Alphanumeric => rng

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Keyspace {
         self.cardinality
     }
 
-    //#TODO(atimmes): implement cardinality for Alphanumeric fields
+    //TODO(aetimmes): implement cardinality for Alphanumeric fields
     pub fn generate_key(&self, rng: &mut SmallRng) -> Vec<u8> {
         match self.key_type {
             FieldType::Alphanumeric => rng

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
 pub struct Keyspace {
     length: usize,
     weight: usize,
+    cardinality: u32,
     commands: Vec<Command>,
     command_dist: WeightedAliasIndex<usize>,
     inner_keys: Vec<InnerKey>,
@@ -44,16 +45,22 @@ impl Keyspace {
         self.length
     }
 
+    pub fn cardinality(&self) -> u32 {
+        self.cardinality
+    }
+
+    //#TODO(atimmes): implement cardinality for Alphanumeric fields
     pub fn generate_key(&self, rng: &mut SmallRng) -> Vec<u8> {
         match self.key_type {
             FieldType::Alphanumeric => rng
                 .sample_iter(&Alphanumeric)
                 .take(self.length())
                 .collect::<Vec<u8>>(),
-            FieldType::U32 => format!("{:010}", &rng.gen::<u32>()).as_bytes().to_vec(),
+            FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..self.cardinality()), len=self.length()).as_bytes().to_vec(),
         }
     }
 
+    //#TODO(atimmes): implement cardinality for Alphanumeric fields
     pub fn generate_inner_key(&self, rng: &mut SmallRng) -> Option<Vec<u8>> {
         if let Some(ref dist) = self.inner_key_dist {
             let idx = dist.sample(rng);
@@ -63,7 +70,7 @@ impl Keyspace {
                     .sample_iter(&Alphanumeric)
                     .take(conf.length())
                     .collect::<Vec<u8>>(),
-                FieldType::U32 => format!("{:010}", &rng.gen::<u32>()).as_bytes().to_vec(),
+                FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..conf.cardinality()), len=conf.length()).as_bytes().to_vec(),
             };
             Some(inner_key)
         } else {
@@ -71,6 +78,7 @@ impl Keyspace {
         }
     }
 
+    //#TODO(atimmes): implement cardinality for Alphanumeric fields
     pub fn generate_value(&self, rng: &mut SmallRng) -> Option<Vec<u8>> {
         if let Some(ref value_dist) = self.value_dist {
             let value_idx = value_dist.sample(rng);
@@ -80,7 +88,7 @@ impl Keyspace {
                     .sample_iter(&Alphanumeric)
                     .take(value_conf.length())
                     .collect::<Vec<u8>>(),
-                FieldType::U32 => format!("{:010}", &rng.gen::<u32>()).as_bytes().to_vec(),
+                FieldType::U32 => format!("{:0>len$}", &rng.gen_range(0u32..value_conf.cardinality()), len=value_conf.length()).as_bytes().to_vec(),
             };
             Some(value)
         } else {
@@ -149,6 +157,7 @@ impl Config {
             let keyspace = Keyspace {
                 length: k.length(),
                 weight: k.weight(),
+                cardinality: k.cardinality(),
                 commands: k.commands(),
                 command_dist,
                 inner_keys: k.inner_keys(),

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -94,6 +94,10 @@ fn one() -> usize {
     1
 }
 
+fn u32_max() -> u32 {
+    u32::MAX;
+}
+
 fn default_nodelay() -> bool {
     false
 }
@@ -101,6 +105,7 @@ fn default_nodelay() -> bool {
 fn alphanumeric() -> FieldType {
     FieldType::Alphanumeric
 }
+
 
 #[derive(Deserialize, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -325,7 +330,7 @@ pub struct Keyspace {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
-    #[serde(default = "u32::max_value")]
+    #[serde(default = "u32_max")]
     cardinality: u32,
     commands: Vec<Command>,
     #[serde(default)]
@@ -443,7 +448,7 @@ pub struct InnerKey {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
-    #[serde(default = "u32::max_value")]
+    #[serde(default = "u32_max")]
     cardinality: u32,
     #[serde(default = "alphanumeric")]
     field_type: FieldType,
@@ -473,7 +478,7 @@ pub struct Value {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
-    #[serde(default = "u32::max_value")]
+    #[serde(default = "u32_max")]
     cardinality: u32,
     #[serde(default = "alphanumeric")]
     field_type: FieldType,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -95,7 +95,7 @@ fn one() -> usize {
 }
 
 fn u32_max() -> u32 {
-    u32::MAX;
+    u32::MAX
 }
 
 fn default_nodelay() -> bool {

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -106,7 +106,6 @@ fn alphanumeric() -> FieldType {
     FieldType::Alphanumeric
 }
 
-
 #[derive(Deserialize, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -325,6 +325,8 @@ pub struct Keyspace {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
+    #[serde(default = "u32::max_value")]
+    cardinality: u32,
     commands: Vec<Command>,
     #[serde(default)]
     inner_keys: Vec<InnerKey>,
@@ -345,6 +347,10 @@ impl Keyspace {
 
     pub fn weight(&self) -> usize {
         self.weight
+    }
+
+    pub fn cardinality(&self) -> u32 {
+        self.cardinality
     }
 
     pub fn inner_keys(&self) -> Vec<InnerKey> {
@@ -437,6 +443,8 @@ pub struct InnerKey {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
+    #[serde(default = "u32::max_value")]
+    cardinality: u32,
     #[serde(default = "alphanumeric")]
     field_type: FieldType,
 }
@@ -450,6 +458,10 @@ impl InnerKey {
         self.length
     }
 
+    pub fn cardinality(&self) -> u32 {
+        self.cardinality
+    }
+
     pub fn field_type(&self) -> FieldType {
         self.field_type
     }
@@ -461,6 +473,8 @@ pub struct Value {
     length: usize,
     #[serde(default = "one")]
     weight: usize,
+    #[serde(default = "u32::max_value")]
+    cardinality: u32,
     #[serde(default = "alphanumeric")]
     field_type: FieldType,
 }
@@ -472,6 +486,10 @@ impl Value {
 
     pub fn length(&self) -> usize {
         self.length
+    }
+
+    pub fn cardinality(&self) -> u32 {
+        self.cardinality
     }
 
     pub fn field_type(&self) -> FieldType {


### PR DESCRIPTION
## Problem

The cardinality of the keyspace being constant (in the case of the U32 field type) or tied directly to the 52^N of the keyspace length (in the case of the Alphanumeric field type) makes it difficult to control the exact size of the keyspace:

len1: 52
len2: 2,704
len3: 140,608
len4: 7,311,616
len5: 380,204,032
len6: 19,770,609,664

The wide gaps between these keyspace cardinalities make it difficult to design load test configurations that achieve a specific hit-rate.

## Solution

This PR implements the "cardinality" config option for key/innerkey/value spaces for U32 field types which constrains the range of the random number generator used to generate these fields.

## Result

See above.

It's worth noting that serde only seems to want to accept functions for defaults, and not literals, so I used u32.max_value() for the default for this field, even though the Rust docs list that function as deprecated (it's being replaced by the u32::MAX constant, which serde doesn't accept). If there's a better way to handle this, let me know.